### PR TITLE
fix: token endpoint auto-discovery for profile-based and interactive auth

### DIFF
--- a/BitPantry.CommandLine.Remote.SignalR.Client/Commands/Server/ConnectCommand.cs
+++ b/BitPantry.CommandLine.Remote.SignalR.Client/Commands/Server/ConnectCommand.cs
@@ -70,22 +70,18 @@ namespace BitPantry.CommandLine.Remote.SignalR.Client.Commands.Server
                 return;
             }
 
-            // validate api key and access token end point
-
-            if(!string.IsNullOrEmpty(ApiKey) || !string.IsNullOrEmpty(TokenRequestEndpoint))
+            // validate: TokenRequestEndpoint requires an ApiKey
+            if (!string.IsNullOrEmpty(TokenRequestEndpoint) && string.IsNullOrEmpty(ApiKey))
             {
-                if(string.IsNullOrEmpty(ApiKey) || string.IsNullOrEmpty(TokenRequestEndpoint))
-                {
-                    Console.MarkupLineInterpolated($"[red]If {nameof(ApiKey)} or {nameof(TokenRequestEndpoint)} are provided, both arguments are required[/]");
-                    return;
-                }
+                Console.MarkupLineInterpolated($"[red]{nameof(ApiKey)} is required when {nameof(TokenRequestEndpoint)} is provided[/]");
+                return;
             }
 
             // check current connection
 
             await CheckCurrentConnection();
 
-            // If API key and explicit token endpoint provided, pre-acquire token
+            // If API key and explicit token endpoint provided, pre-acquire token (skip discovery round-trip)
             if (!string.IsNullOrEmpty(ApiKey) && !string.IsNullOrEmpty(TokenRequestEndpoint))
             {
                 try
@@ -94,7 +90,7 @@ namespace BitPantry.CommandLine.Remote.SignalR.Client.Commands.Server
                 }
                 catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                 {
-                    Console.MarkupLine("Requesting token with API key is unauthorized - make sure you are using a valid API key");
+                    Console.MarkupLine("[red]Requesting token with API key is unauthorized - make sure you are using a valid API key[/]");
                     return;
                 }
             }
@@ -129,8 +125,8 @@ namespace BitPantry.CommandLine.Remote.SignalR.Client.Commands.Server
             }
             catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
-                // Extract token endpoint from unauthorized response
-                var tokenEndpoint = ConnectionService.ExtractTokenEndpoint(ex);
+                // Discover token endpoint via direct HTTP probe
+                var tokenEndpoint = await _connectionService.DiscoverTokenEndpointAsync(Uri);
                 if (string.IsNullOrEmpty(tokenEndpoint))
                 {
                     Console.WriteLine($"The connection requires an access token, but the server did not provide the end-point " +

--- a/BitPantry.CommandLine.Remote.SignalR.Client/ConnectionService.cs
+++ b/BitPantry.CommandLine.Remote.SignalR.Client/ConnectionService.cs
@@ -28,7 +28,9 @@ namespace BitPantry.CommandLine.Remote.SignalR.Client
 
         /// <summary>
         /// Connects to the server, automatically handling the 401 → token acquisition → retry
-        /// flow when an API key is available.
+        /// flow when an API key is available. Uses a direct HTTP probe to discover the token
+        /// endpoint from the server's 401 response, since SignalR does not preserve response
+        /// body data in its exceptions.
         /// </summary>
         /// <param name="proxy">The server proxy to connect through</param>
         /// <param name="uri">The server URI</param>
@@ -47,7 +49,7 @@ namespace BitPantry.CommandLine.Remote.SignalR.Client
                 if (string.IsNullOrEmpty(apiKey))
                     throw; // Caller must handle (e.g., prompt user for API key)
 
-                var tokenEndpoint = ExtractTokenEndpoint(ex);
+                var tokenEndpoint = await DiscoverTokenEndpointAsync(uri, token);
                 if (string.IsNullOrEmpty(tokenEndpoint))
                     throw new InvalidOperationException(
                         "Server requires authorization but did not provide a token endpoint", ex);
@@ -104,24 +106,36 @@ namespace BitPantry.CommandLine.Remote.SignalR.Client
         }
 
         /// <summary>
-        /// Extracts the token request endpoint from an HttpRequestException's Data dictionary.
-        /// The DefaultHttpMessageHandler stashes the response body there on 401 responses.
+        /// Discovers the token request endpoint by making a direct HTTP request to the
+        /// server's hub negotiate endpoint. If the server requires authentication, it
+        /// returns a 401 response containing the token_request_endpoint in the body.
+        /// This approach bypasses SignalR's exception handling which does not preserve
+        /// the response body.
         /// </summary>
-        /// <param name="ex">The HTTP request exception from a 401 response</param>
-        /// <returns>The token endpoint path, or null if not available</returns>
-        public static string ExtractTokenEndpoint(HttpRequestException ex)
+        /// <param name="hubUri">The hub URI (e.g., http://localhost:5115/cli)</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The token endpoint path, or null if not discoverable</returns>
+        public async Task<string> DiscoverTokenEndpointAsync(string hubUri, CancellationToken token = default)
         {
             try
             {
-                var responseBody = ex.Data["responseBody"]?.ToString();
-                if (string.IsNullOrEmpty(responseBody))
+                var negotiateUrl = hubUri.TrimEnd('/') + "/negotiate?negotiateVersion=1";
+                var client = _httpClientFactory.CreateClient();
+                var response = await client.PostAsync(negotiateUrl, null, token);
+
+                if (response.StatusCode != HttpStatusCode.Unauthorized)
                     return null;
 
-                var resp = JsonSerializer.Deserialize<UnauthorizedResponse>(responseBody);
+                var body = await response.Content.ReadAsStringAsync(token);
+                if (string.IsNullOrEmpty(body))
+                    return null;
+
+                var resp = JsonSerializer.Deserialize<UnauthorizedResponse>(body);
                 return resp?.TokenRequestEndpoint;
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogDebug(ex, "Failed to discover token endpoint from {HubUri}", hubUri);
                 return null;
             }
         }

--- a/BitPantry.CommandLine.Remote.SignalR.Client/DefaultHttpMessageHandler.cs
+++ b/BitPantry.CommandLine.Remote.SignalR.Client/DefaultHttpMessageHandler.cs
@@ -1,5 +1,6 @@
 ﻿/// <summary>
-/// Extends the <see cref="HttpClientHandler"/> to throw an exception when receiving an unauthorized response - the response body is added to the exception data
+/// Extends the <see cref="HttpClientHandler"/> to throw an exception when receiving an unauthorized
+/// response. This ensures SignalR connection attempts fail immediately on 401.
 /// </summary>
 public class DefaultHttpMessageHandler : HttpClientHandler
 {
@@ -9,10 +10,7 @@ public class DefaultHttpMessageHandler : HttpClientHandler
 
         if(response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
         {
-            var ex = new HttpRequestException("Unauthorized", null, System.Net.HttpStatusCode.Unauthorized);
-            ex.Data["responseBody"] = await response.Content.ReadAsStringAsync();
-
-            throw ex;
+            throw new HttpRequestException("Unauthorized", null, System.Net.HttpStatusCode.Unauthorized);
         }
 
         return response;

--- a/BitPantry.CommandLine.Tests.Remote.SignalR/ClientTests/ConnectionServiceTests.cs
+++ b/BitPantry.CommandLine.Tests.Remote.SignalR/ClientTests/ConnectionServiceTests.cs
@@ -1,0 +1,229 @@
+using BitPantry.CommandLine.Client;
+using BitPantry.CommandLine.Remote.SignalR.Client;
+using BitPantry.CommandLine.Tests.Infrastructure.Authentication;
+using BitPantry.CommandLine.Tests.Infrastructure.Helpers;
+using BitPantry.CommandLine.Tests.Infrastructure.Http;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Net;
+using System.Text.Json;
+using IHttpClientFactory = BitPantry.CommandLine.Remote.SignalR.Client.IHttpClientFactory;
+
+namespace BitPantry.CommandLine.Tests.Remote.SignalR.ClientTests
+{
+    /// <summary>
+    /// Unit tests for ConnectionService.
+    /// Covers token endpoint auto-discovery and the ConnectWithAuth flow.
+    /// </summary>
+    [TestClass]
+    public class ConnectionServiceTests
+    {
+        private Mock<IServerProxy> _proxyMock;
+        private Mock<ILogger<ConnectionService>> _loggerMock;
+        private ConnectionService _service;
+        private Mock<IHttpClientFactory> _httpClientFactoryMock;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _proxyMock = new Mock<IServerProxy>();
+            _proxyMock.SetupGet(p => p.ConnectionState).Returns(ServerProxyConnectionState.Disconnected);
+
+            _loggerMock = new Mock<ILogger<ConnectionService>>();
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+
+            var accessTokenManager = TestAccessTokenManager.Create(
+                new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+            _service = new ConnectionService(
+                _loggerMock.Object,
+                accessTokenManager,
+                _httpClientFactoryMock.Object);
+        }
+
+        #region DiscoverTokenEndpointAsync
+
+        [TestMethod]
+        public async Task DiscoverTokenEndpointAsync_ServerReturns401WithEndpoint_ReturnsEndpoint()
+        {
+            // Arrange — server returns 401 with token_request_endpoint in body
+            // Bug: Currently no DiscoverTokenEndpointAsync method exists.
+            // This test drives its creation.
+            var responseBody = JsonSerializer.Serialize(new
+            {
+                error = "Unauthorized",
+                message = "Token is missing",
+                token_request_endpoint = "/cli-auth/token-request",
+                token_format = "Bearer {JWT}"
+            });
+
+            var response = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent(responseBody, System.Text.Encoding.UTF8, "application/json")
+            };
+
+            _httpClientFactoryMock.Setup(f => f.CreateClient())
+                .Returns(TestHttpClient.Create(response));
+
+            // Act
+            var endpoint = await _service.DiscoverTokenEndpointAsync("http://localhost:5115/cli");
+
+            // Assert
+            endpoint.Should().Be("/cli-auth/token-request");
+        }
+
+        [TestMethod]
+        public async Task DiscoverTokenEndpointAsync_ServerReturns401WithoutEndpoint_ReturnsNull()
+        {
+            // Arrange — server returns 401 but body has no token_request_endpoint
+            var response = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("{\"error\":\"Unauthorized\"}", System.Text.Encoding.UTF8, "application/json")
+            };
+
+            _httpClientFactoryMock.Setup(f => f.CreateClient())
+                .Returns(TestHttpClient.Create(response));
+
+            // Act
+            var endpoint = await _service.DiscoverTokenEndpointAsync("http://localhost:5115/cli");
+
+            // Assert
+            endpoint.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task DiscoverTokenEndpointAsync_ServerReturns200_ReturnsNull()
+        {
+            // Arrange — server doesn't require auth (returns 200)
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json")
+            };
+
+            _httpClientFactoryMock.Setup(f => f.CreateClient())
+                .Returns(TestHttpClient.Create(response));
+
+            // Act
+            var endpoint = await _service.DiscoverTokenEndpointAsync("http://localhost:5115/cli");
+
+            // Assert — no auth required, so no endpoint to discover
+            endpoint.Should().BeNull();
+        }
+
+        #endregion
+
+        #region ConnectWithAuthAsync — Auto-Discovery
+
+        [TestMethod]
+        public async Task ConnectWithAuthAsync_ProfileApiKeyNoExplicitEndpoint_DiscoversAndConnects()
+        {
+            // Arrange — proxy returns 401 on first connect (SignalR doesn't preserve response body),
+            // then discovery probe finds the endpoint, token is acquired, second connect succeeds.
+            //
+            // Bug: Currently ConnectWithAuthAsync relies on ExtractTokenEndpoint(ex) which
+            // fails because SignalR doesn't preserve ex.Data["responseBody"].
+            // This test drives the fix to use DiscoverTokenEndpointAsync as fallback.
+
+            var connectAttempt = 0;
+            _proxyMock.Setup(p => p.Connect(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    connectAttempt++;
+                    if (connectAttempt == 1)
+                    {
+                        // First attempt: 401 WITHOUT response body in Data (simulates SignalR behavior)
+                        throw new HttpRequestException("Unauthorized", null, HttpStatusCode.Unauthorized);
+                    }
+                    return Task.CompletedTask; // Second attempt succeeds (token acquired)
+                });
+
+            // Discovery probe returns 401 with token endpoint
+            var discoveryResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        error = "Unauthorized",
+                        message = "Token is missing",
+                        token_request_endpoint = "/cli-auth/token-request",
+                        token_format = "Bearer {JWT}"
+                    }),
+                    System.Text.Encoding.UTF8, "application/json")
+            };
+
+            // Token acquisition response
+            var tokenResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        accessToken = "test-jwt-token",
+                        refreshToken = "test-refresh-token",
+                        refreshRoute = "/cli-auth/token-refresh"
+                    }),
+                    System.Text.Encoding.UTF8, "application/json")
+            };
+
+            // HTTP client factory returns clients for discovery + token acquisition
+            var callIndex = 0;
+            _httpClientFactoryMock.Setup(f => f.CreateClient())
+                .Returns(() =>
+                {
+                    callIndex++;
+                    if (callIndex == 1)
+                        return TestHttpClient.Create(discoveryResponse);
+                    return TestHttpClient.Create(tokenResponse);
+                });
+
+            // Need a ConnectionService with a real AccessTokenManager that accepts tokens
+            var accessTokenManager = TestAccessTokenManager.Create(tokenResponse);
+            var service = new ConnectionService(
+                _loggerMock.Object,
+                accessTokenManager,
+                _httpClientFactoryMock.Object);
+
+            // Act — should not throw
+            await service.ConnectWithAuthAsync(_proxyMock.Object, "http://localhost:5115/cli", "my-api-key");
+
+            // Assert — proxy.Connect called twice: first 401, then success after token acquisition
+            _proxyMock.Verify(p => p.Connect(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [TestMethod]
+        public async Task ConnectWithAuthAsync_NoApiKey_401_Throws()
+        {
+            // Arrange — no API key, proxy returns 401
+            _proxyMock.Setup(p => p.Connect(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException("Unauthorized", null, HttpStatusCode.Unauthorized));
+
+            // Act & Assert — should re-throw for caller to handle (e.g., interactive prompt)
+            var act = () => _service.ConnectWithAuthAsync(_proxyMock.Object, "http://localhost:5115/cli", null);
+            await act.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        [TestMethod]
+        public async Task ConnectWithAuthAsync_ApiKeyButNoEndpointDiscovered_ThrowsInvalidOperation()
+        {
+            // Arrange — proxy returns 401, discovery probe also fails to find endpoint
+            _proxyMock.Setup(p => p.Connect(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException("Unauthorized", null, HttpStatusCode.Unauthorized));
+
+            // Discovery returns 401 but with no token_request_endpoint
+            var discoveryResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("{\"error\":\"Unauthorized\"}", System.Text.Encoding.UTF8, "application/json")
+            };
+
+            _httpClientFactoryMock.Setup(f => f.CreateClient())
+                .Returns(TestHttpClient.Create(discoveryResponse));
+
+            // Act & Assert
+            var act = () => _service.ConnectWithAuthAsync(_proxyMock.Object, "http://localhost:5115/cli", "my-api-key");
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("*token endpoint*");
+        }
+
+        #endregion
+    }
+}

--- a/sandbox/SandboxClient/Commands/ExploreCommands.cs
+++ b/sandbox/SandboxClient/Commands/ExploreCommands.cs
@@ -1,3 +1,4 @@
+using BitPantry.CommandLine;
 using BitPantry.CommandLine.API;
 using BitPantry.CommandLine.AutoComplete;
 using BitPantry.CommandLine.AutoComplete.Handlers;

--- a/sandbox/SandboxServer/Commands/RemoteExploreCommands.cs
+++ b/sandbox/SandboxServer/Commands/RemoteExploreCommands.cs
@@ -1,3 +1,4 @@
+using BitPantry.CommandLine;
 using BitPantry.CommandLine.API;
 using BitPantry.CommandLine.AutoComplete;
 using BitPantry.CommandLine.AutoComplete.Handlers;


### PR DESCRIPTION
## Problem

Two bugs prevent `server connect` from authenticating:

### Bug 1: Guard clause too strict (profile + API key)
When running `server connect tabs-local`, a profile with an API key but no explicit `--token-request-endpoint` is rejected by the guard clause that requires both. The error: *"If ApiKey or TokenRequestEndpoint are provided, both arguments are required"*.

### Bug 2: Token endpoint extraction fails through SignalR (interactive path)
When running `server connect --uri http://localhost:5115/cli` without an API key, the interactive auth flow catches the 401 and tries to extract the `token_request_endpoint` from the exception. This fails because SignalR wraps/re-throws exceptions — the `Data["responseBody"]` stashed by `DefaultHttpMessageHandler` is lost. The error: *"the server did not provide the end-point information required to obtain an access token"*.

## Solution

### New: `ConnectionService.DiscoverTokenEndpointAsync()`
A direct HTTP POST to the hub's `/negotiate` endpoint using a bare `HttpClient` (bypasses SignalR). Reads the 401 response body directly to extract `token_request_endpoint`. Reliable because it doesn't depend on exception data preservation.

### Updated: `ConnectWithAuthAsync()`
Uses `DiscoverTokenEndpointAsync()` instead of the broken `ExtractTokenEndpoint()` when a 401 occurs and an API key is available.

### Updated: `ConnectCommand` guard clause
Removed the requirement that both `ApiKey` and `TokenRequestEndpoint` must be provided together. Now only `TokenRequestEndpoint` requires an `ApiKey` (as an explicit override to skip the discovery round-trip).

### Cleanup
- Removed dead `ExtractTokenEndpoint()` method (never worked through SignalR)
- Removed response body stashing from `DefaultHttpMessageHandler` (no consumers)
- Simplified `DefaultHttpMessageHandler` doc comment

## Tests

Added `ConnectionServiceTests` with 6 unit tests:
- `DiscoverTokenEndpointAsync` — 401 with endpoint, 401 without endpoint, 200 (no auth)
- `ConnectWithAuthAsync` — auto-discovery flow, no API key re-throw, no endpoint discovered

## Verification

All tests pass (0 failures):
- BitPantry.CommandLine.Tests: 881 passed
- BitPantry.CommandLine.Tests.Remote.SignalR: 832 passed
- BitPantry.VirtualConsole.Tests: 255 passed