### PR TITLE
Spec 012: Client File Access

### DIFF
--- a/specs/012-client-file-access/data-model.md
+++ b/specs/012-client-file-access/data-model.md
@@ -1,0 +1,244 @@
+# Data Model: Client File Access (012-client-file-access)
+
+> Defines all new types, message envelopes, and service interfaces introduced by this feature.
+
+---
+
+## Core Interface
+
+### `IClientFileAccess` (new, `BitPantry.CommandLine` project)
+
+Location-transparent file access service. Commands inject this to read/write files on the calling user's machine.
+
+```csharp
+public interface IClientFileAccess
+{
+    Task<ClientFile> GetFileAsync(string clientPath, IProgress<FileTransferProgress>? progress = null, CancellationToken ct = default);
+
+    IAsyncEnumerable<ClientFile> GetFilesAsync(string clientGlobPattern, IProgress<FileTransferProgress>? progress = null, CancellationToken ct = default);
+
+    Task SaveFileAsync(Stream content, string clientPath, IProgress<FileTransferProgress>? progress = null, CancellationToken ct = default);
+
+    Task SaveFileAsync(string sourcePath, string clientPath, IProgress<FileTransferProgress>? progress = null, CancellationToken ct = default);
+}
+```
+
+Design notes:
+- Uses `IProgress<T>` (standard .NET pattern) instead of `Func<T, Task>` — composable, non-blocking, well-understood.
+- `GetFilesAsync` returns `IAsyncEnumerable<ClientFile>` for lazy per-file transfer.
+- `CancellationToken` is last parameter (convention).
+
+### `ClientFile` (new, `BitPantry.CommandLine` project)
+
+Disposable handle returned by `GetFileAsync` / `GetFilesAsync`. Provides stream access and metadata.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Stream` | `Stream` | Readable stream of file content |
+| `FileName` | `string` | File name (no directory) |
+| `Length` | `long` | File size in bytes |
+
+```csharp
+public sealed class ClientFile : IAsyncDisposable
+{
+    public Stream Stream { get; }
+    public string FileName { get; }
+    public long Length { get; }
+
+    private readonly Func<ValueTask>? _cleanupAsync;
+
+    public ClientFile(Stream stream, string fileName, long length, Func<ValueTask>? cleanupAsync = null)
+    {
+        Stream = stream;
+        FileName = fileName;
+        Length = length;
+        _cleanupAsync = cleanupAsync;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Stream.DisposeAsync();
+        if (_cleanupAsync != null)
+            await _cleanupAsync();
+    }
+}
+```
+
+**Local implementation**: `cleanupAsync` is null — just closes the `FileStream`.
+**Remote implementation**: `cleanupAsync` deletes the server-side temp file.
+
+### `FileTransferProgress` (new, `BitPantry.CommandLine` project)
+
+```csharp
+public record FileTransferProgress(long BytesTransferred, long TotalBytes);
+```
+
+### `FileAccessDeniedException` (new, `BitPantry.CommandLine` project)
+
+```csharp
+public class FileAccessDeniedException : Exception
+{
+    public string RequestedPath { get; }
+    public FileAccessDeniedException(string requestedPath)
+        : base($"File access denied by client: {requestedPath}")
+    {
+        RequestedPath = requestedPath;
+    }
+}
+```
+
+---
+
+## Implementations
+
+### `LocalClientFileAccess` (new, `BitPantry.CommandLine` project)
+
+Used when commands run locally. Direct file system operations, no network.
+
+| Method | Implementation |
+|--------|---------------|
+| `GetFileAsync` | Open `FileStream(path, Read, Share.Read)`, return `ClientFile` |
+| `GetFilesAsync` | Expand glob via `GlobPatternHelper` + `FileSystemGlobbing`, yield `ClientFile` per match |
+| `SaveFileAsync(stream, ...)` | Create parent dirs, write stream to path |
+| `SaveFileAsync(path, ...)` | Create parent dirs, `File.Copy(source, dest, overwrite: true)` |
+
+Dependencies: `IFileSystem`
+
+### `RemoteClientFileAccess` (new, `BitPantry.CommandLine.Remote.SignalR.Server` project)
+
+Used when commands run on the server. Coordinates file transfers via SignalR push messages + existing HTTP endpoints.
+
+| Method | Implementation |
+|--------|---------------|
+| `GetFileAsync` | Send `ClientFileUploadRequest` push → client uploads to server temp → open temp file → return `ClientFile` (cleanup deletes temp) |
+| `GetFilesAsync` | Send `ClientFileEnumerateRequest` push → client expands glob → sends file list → consent → yield each file via individual `GetFileAsync` |
+| `SaveFileAsync(stream, ...)` | Write stream to server temp → send `ClientFileDownloadRequest` push → client downloads from server temp → delete temp |
+| `SaveFileAsync(path, ...)` | Send `ClientFileDownloadRequest` push referencing the source path directly → client downloads from server |
+
+Dependencies: `HubInvocationContext`, `RpcMessageRegistry`, `IFileSystem` (for temp file management), `FileTransferOptions` (for `MaxFileSizeBytes`, staging path)
+
+---
+
+## Protocol Messages
+
+All messages follow existing `MessageBase` pattern with `Dictionary<string, string>` data.
+
+### New `PushMessageType` Values
+
+```csharp
+public enum PushMessageType
+{
+    FileUploadProgress,           // existing
+    ClientFileUploadRequest,      // NEW: server asks client to upload a file
+    ClientFileDownloadRequest,    // NEW: server asks client to download a file
+    ClientFileEnumerateRequest    // NEW: server asks client to expand a glob pattern
+}
+```
+
+### `ClientFileUploadRequest` (server → client push)
+
+Server asks client to upload a specific file to the server.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CorrelationId` | `string` | For matching response |
+| `ClientPath` | `string` | Path on client machine |
+| `ServerTempPath` | `string` | Where to upload on server (via existing `/fileupload` endpoint) |
+
+### `ClientFileDownloadRequest` (server → client push)
+
+Server asks client to download a file from the server.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CorrelationId` | `string` | For matching response |
+| `ServerPath` | `string` | Path on server to download (via existing `/filedownload` endpoint) |
+| `ClientPath` | `string` | Where to save on client |
+| `FileSize` | `long` | For progress tracking |
+
+### `ClientFileEnumerateRequest` (server → client push)
+
+Server asks client to expand a glob pattern and return matched file info.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CorrelationId` | `string` | For matching response |
+| `GlobPattern` | `string` | Glob pattern to expand on client |
+
+### New `ServerRequestType` Value (for responses)
+
+```csharp
+public enum ServerRequestType
+{
+    // ... existing ...
+    ClientFileAccessResponse = 6   // NEW: client sends result of file access operation
+}
+```
+
+### `ClientFileAccessResponse` (client → server)
+
+Generic response for all client file access operations.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CorrelationId` | `string` | Matches the originating push message |
+| `Success` | `bool` | Whether the operation succeeded |
+| `Error` | `string?` | Error message if failed |
+| `FileInfoEntries` | `string?` | JSON array of `{Path, Size}` for enumerate responses |
+
+---
+
+## Consent Infrastructure
+
+### `FileAccessConsentPolicy` (new, `BitPantry.CommandLine.Remote.SignalR.Client` project)
+
+Evaluates whether a file access request requires user consent.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `AllowedPatterns` | `IReadOnlyList<string>` | Glob patterns from `--allow-path` |
+
+| Method | Behavior |
+|--------|----------|
+| `IsAllowed(string path)` | Returns `true` if path matches any allowed pattern |
+| `RequiresConsent(string path)` | Returns `!IsAllowed(path)` |
+| `RequiresConsent(IEnumerable<string> paths)` | Returns paths not covered by allowed patterns |
+
+### `FileAccessConsentHandler` (new, `BitPantry.CommandLine.Remote.SignalR.Client` project)
+
+Manages the consent prompt UX including console output buffering.
+
+| Method | Behavior |
+|--------|----------|
+| `RequestConsentAsync(string path, CancellationToken)` | Evaluates policy → if allowed, returns true; else pauses output, shows prompt, resumes output |
+| `RequestBatchConsentAsync(IReadOnlyList<string> paths, IReadOnlyList<long> sizes, string pattern, CancellationToken)` | Same but tiered batch display based on count thresholds |
+
+Dependencies: `FileAccessConsentPolicy`, `IAnsiConsole` (for prompt rendering), console output pause/resume mechanism.
+
+---
+
+## Constants
+
+| Constant | Value | Used By |
+|----------|-------|---------|
+| `ClientFileAccessStagingDir` | `.client-file-staging` | `RemoteClientFileAccess` — temp dir within sandbox for staging transfers |
+| `ConsentFullListThreshold` | `10` | `FileAccessConsentHandler` — show all files individually at or below this count |
+| `ConsentSummaryOnlyThreshold` | `50` | `FileAccessConsentHandler` — show summary only (no file list) above this count |
+| `ConsentCollapsedHeadCount` | `5` | `FileAccessConsentHandler` — number of files to show at top of collapsed list |
+| `ConsentCollapsedTailCount` | `2` | `FileAccessConsentHandler` — number of files to show at bottom of collapsed list |
+
+---
+
+## Relationship to Existing Entities
+
+| Existing Entity | Relationship |
+|----------------|-------------|
+| `FileTransferService` | Client-side handler calls `UploadFile()` / `DownloadFile()` to perform actual HTTP transfer |
+| `FileTransferEndpointService` | Server HTTP endpoints serve/receive files — no changes needed |
+| `PushMessage` / `ReceiveMessage` | Extended with new message types for server→client file access requests |
+| `ServerRequest` / `ReceiveRequest` | Extended with response type for client→server file access completions |
+| `HubInvocationContext` | `RemoteClientFileAccess` uses this to send push messages to the calling client |
+| `RpcMessageRegistry` | Used for correlation between push request and client response |
+| `GlobPatternHelper` | Reused by both `LocalClientFileAccess` (local expansion) and client handler (remote expansion) |
+| `ConnectCommand` | Extended with `--allow-path` argument |
+| `CommandLineClientSettings` | Extended to store allowed path patterns for the session |

--- a/specs/012-client-file-access/issues/000-tracking.md
+++ b/specs/012-client-file-access/issues/000-tracking.md
@@ -1,0 +1,32 @@
+# Spec 012: Client File Access
+
+Tracking issue for the 012-client-file-access feature specification.
+
+**Spec**: `specs/012-client-file-access/spec.md`
+**Plan**: `specs/012-client-file-access/plan.md`
+
+## Overview
+
+Add a location-transparent `IClientFileAccess` service that lets commands read and write files on the user's machine regardless of whether the command runs locally or on a remote server. Includes consent prompts for server-initiated file access, glob pattern support, and full reuse of existing HTTP file transfer infrastructure.
+
+## Issues
+
+### Phase 1: Core Types & Foundation
+- [ ] 001 — Core types: IClientFileAccess, ClientFile, and local implementation
+- [ ] 002 — Protocol message envelopes for client file access
+- [ ] 004 — File access consent policy and ConnectCommand --allow-path
+
+### Phase 2: Server & Client Implementations
+- [ ] 003 — RemoteClientFileAccess server implementation (blocked by 001, 002)
+- [ ] 005 — Client-side push message handler and consent UX (blocked by 002, 004)
+
+### Phase 3: Integration & Round-Trip
+- [ ] 006 — End-to-end integration: single file GetFile and SaveFile (blocked by 003, 005)
+
+### Phase 4: Glob & Hardening
+- [ ] 007 — Glob pattern support: GetFilesAsync with lazy enumeration (blocked by 006)
+- [ ] 008 — Edge cases and hardening (blocked by 006, 007)
+
+## Labels
+
+- `spec-012`

--- a/specs/012-client-file-access/issues/001-core-types-and-local-impl.md
+++ b/specs/012-client-file-access/issues/001-core-types-and-local-impl.md
@@ -1,0 +1,163 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 001
+  GitHub Issue Number: #51
+-->
+
+# Core types: IClientFileAccess, ClientFile, and local implementation
+
+**Labels**: enhancement, spec-012
+**Blocked by**: None
+**Implements**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-008, FR-015, FR-019
+**Covers**: US-003
+
+## Summary
+
+Introduce the `IClientFileAccess` interface, `ClientFile` disposable file handle, `FileTransferProgress` record, `FileAccessDeniedException`, and the `LocalClientFileAccess` implementation. This establishes the API contract that all command authors will use and provides the local (client-side) implementation where file operations go directly to disk with no network transfer.
+
+## Current Behavior
+
+No `IClientFileAccess` service exists. Commands that need to interact with client-side files must use `IFileSystem` directly (which is the local file system on the client but the sandboxed server file system on the server). There is no location-transparent file access abstraction.
+
+## Expected Behavior
+
+Commands can inject `IClientFileAccess` and call `GetFileAsync`, `SaveFileAsync(Stream, ...)`, and `SaveFileAsync(string, ...)` to read/write files on the user's machine. When running locally, `LocalClientFileAccess` performs direct file I/O. The interface, types, and local implementation are all available in the core `BitPantry.CommandLine` project.
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine`
+- **Key files:**
+  - `BitPantry.CommandLine/Client/IClientFileAccess.cs` — NEW: interface definition
+  - `BitPantry.CommandLine/Client/ClientFile.cs` — NEW: disposable file handle
+  - `BitPantry.CommandLine/Client/FileTransferProgress.cs` — NEW: progress record
+  - `BitPantry.CommandLine/Client/FileAccessDeniedException.cs` — NEW: exception type
+  - `BitPantry.CommandLine/Client/LocalClientFileAccess.cs` — NEW: local implementation
+  - `BitPantry.CommandLine/ServiceCollectionExtensions.cs` — MODIFY: register default DI
+- **Spec reference:** See `specs/012-client-file-access/spec.md`
+- **Plan reference:** See `specs/012-client-file-access/plan.md`
+- **Data model reference:** See `specs/012-client-file-access/data-model.md`
+
+## Requirements
+
+- [ ] `IClientFileAccess` interface exists with `GetFileAsync(string, IProgress<FileTransferProgress>?, CancellationToken)` returning `Task<ClientFile>` (FR-001, FR-002)
+- [ ] `IClientFileAccess` interface has `SaveFileAsync(Stream, string, IProgress<FileTransferProgress>?, CancellationToken)` (FR-003, FR-019)
+- [ ] `IClientFileAccess` interface has `SaveFileAsync(string, string, IProgress<FileTransferProgress>?, CancellationToken)` (FR-004, FR-019)
+- [ ] All methods accept `CancellationToken` (FR-015)
+- [ ] All methods accept optional `IProgress<FileTransferProgress>` callback (FR-019)
+- [ ] `ClientFile` implements `IAsyncDisposable` with `Stream`, `FileName`, and `Length` properties (FR-002)
+- [ ] `ClientFile` disposal calls cleanup action if provided (FR-002)
+- [ ] `LocalClientFileAccess.GetFileAsync` opens a `FileStream` for reading and returns a `ClientFile` (FR-005)
+- [ ] `LocalClientFileAccess.GetFileAsync` throws `FileNotFoundException` for missing files (FR-005)
+- [ ] `LocalClientFileAccess.SaveFileAsync(Stream, ...)` writes stream to the specified path (FR-005)
+- [ ] `LocalClientFileAccess.SaveFileAsync(Stream, ...)` creates parent directories if they don't exist (FR-008)
+- [ ] `LocalClientFileAccess.SaveFileAsync(string, ...)` copies the source file to the destination (FR-005)
+- [ ] `LocalClientFileAccess.SaveFileAsync(string, ...)` creates parent directories if they don't exist (FR-008)
+- [ ] `LocalClientFileAccess` is registered as the default `IClientFileAccess` in DI (FR-001)
+
+## Prerequisites
+
+No prerequisites — this issue can be started independently.
+
+## Implementation Guidance
+
+### Interface Design
+
+Place all types in `BitPantry.CommandLine/Client/` alongside existing `IServerProxy.cs` and `NoopServerProxy.cs`.
+
+```csharp
+public interface IClientFileAccess
+{
+    Task<ClientFile> GetFileAsync(string clientPath, IProgress<FileTransferProgress>? progress = null, CancellationToken ct = default);
+    Task SaveFileAsync(Stream content, string clientPath, IProgress<FileTransferProgress>? progress = null, CancellationToken ct = default);
+    Task SaveFileAsync(string sourcePath, string clientPath, IProgress<FileTransferProgress>? progress = null, CancellationToken ct = default);
+}
+```
+
+Note: `GetFilesAsync` (glob) is added in issue 007. Do not include it here.
+
+### ClientFile
+
+```csharp
+public sealed class ClientFile : IAsyncDisposable
+{
+    public Stream Stream { get; }
+    public string FileName { get; }
+    public long Length { get; }
+    private readonly Func<ValueTask>? _cleanupAsync;
+
+    public ClientFile(Stream stream, string fileName, long length, Func<ValueTask>? cleanupAsync = null) { ... }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Stream.DisposeAsync();
+        if (_cleanupAsync != null) await _cleanupAsync();
+    }
+}
+```
+
+### LocalClientFileAccess
+
+Depends on `IFileSystem` (already registered as singleton). For `SaveFileAsync(Stream, ...)`, stream the content to a `FileStream` in chunks (same 81920-byte buffer as existing `FileTransferService`). Report progress via `IProgress<T>` if provided.
+
+### DI Registration
+
+In `ServiceCollectionExtensions.cs`, add `LocalClientFileAccess` as the default singleton:
+
+```csharp
+services.AddSingleton<IClientFileAccess, LocalClientFileAccess>();
+```
+
+The server project will override this with `RemoteClientFileAccess` (scoped) in issue 003.
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Unit (MockFileSystem for isolation)
+- **Test project:** `BitPantry.CommandLine.Tests`
+- **Existing fixtures to reuse:** None needed — pure unit tests with `MockFileSystem` from `System.IO.Abstractions.TestingHelpers`
+
+### Prescribed Test Cases
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `GetFileAsync_ExistingFile_ReturnsClientFileWithStream` | File exists on disk | Returns `ClientFile` with readable stream, correct `FileName` and `Length` |
+| 2 | `GetFileAsync_MissingFile_ThrowsFileNotFoundException` | File does not exist | Throws `FileNotFoundException` |
+| 3 | `SaveFileAsync_Stream_WritesToDisk` | Save a MemoryStream to a path | File exists at path with correct content |
+| 4 | `SaveFileAsync_Stream_CreatesParentDirectories` | Save to path where parent dir doesn't exist | Parent dirs created, file written |
+| 5 | `SaveFileAsync_Path_CopiesFile` | Save from existing source path to destination | Destination has same content as source |
+| 6 | `SaveFileAsync_Path_CreatesParentDirectories` | Destination parent dir doesn't exist | Parent dirs created, file copied |
+| 7 | `SaveFileAsync_Stream_OverwritesExistingFile` | Destination already exists | File overwritten with new content |
+| 8 | `ClientFile_DisposeAsync_ClosesStream` | Dispose a ClientFile | Stream is disposed |
+| 9 | `ClientFile_DisposeAsync_CallsCleanupAction` | Dispose with cleanup action | Cleanup action invoked |
+| 10 | `ClientFile_DisposeAsync_NullCleanup_NoError` | Dispose without cleanup action | No error thrown |
+| 11 | `GetFileAsync_WithProgress_ReportsProgress` | Read file with IProgress provided | Progress reported with correct BytesTransferred/TotalBytes |
+| 12 | `SaveFileAsync_WithCancellation_ThrowsOperationCanceled` | Cancel during save | Throws `OperationCanceledException` |
+
+### Integration Tests
+
+| # | Test Name Pattern | Scenario | Expected Outcome | Infrastructure |
+|---|-------------------|----------|------------------|----------------|
+| 13 | `SaveFile_LocalCommand_WritesDirectly` | Register command locally that saves via `IClientFileAccess` → run | File written to temp dir | `CommandLineApplication` (no server) |
+| 14 | `GetFile_LocalCommand_ReadsDirectly` | Place file → register command locally that reads via `IClientFileAccess` → run | Command receives correct content | `CommandLineApplication` (no server) |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor.

--- a/specs/012-client-file-access/issues/002-protocol-message-envelopes.md
+++ b/specs/012-client-file-access/issues/002-protocol-message-envelopes.md
@@ -1,0 +1,132 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 002
+  GitHub Issue Number: #52
+-->
+
+# Protocol message envelopes for client file access
+
+**Labels**: enhancement, spec-012
+**Blocked by**: None
+**Implements**: FR-006, FR-016, FR-017
+**Covers**: —
+
+## Summary
+
+Add the SignalR message envelopes and type extensions needed for the server to request file operations from the client and for the client to respond. This is the shared protocol layer — no business logic, just message definitions.
+
+## Current Behavior
+
+`PushMessageType` has only `FileUploadProgress`. `ServerRequestType` has no file access response type. There are no message classes for server-initiated file access requests.
+
+## Expected Behavior
+
+Three new `PushMessageType` values (`ClientFileUploadRequest`, `ClientFileDownloadRequest`, `ClientFileEnumerateRequest`), one new `ServerRequestType` value (`ClientFileAccessResponse`), and corresponding message envelope classes exist in the shared `BitPantry.CommandLine.Remote.SignalR` project.
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine.Remote.SignalR`
+- **Key files:**
+  - `BitPantry.CommandLine.Remote.SignalR/Envelopes/PushMessage.cs` — MODIFY: add enum values
+  - `BitPantry.CommandLine.Remote.SignalR/Envelopes/ServerRequest.cs` — MODIFY: add enum value
+  - `BitPantry.CommandLine.Remote.SignalR/Envelopes/ClientFileUploadRequestMessage.cs` — NEW
+  - `BitPantry.CommandLine.Remote.SignalR/Envelopes/ClientFileDownloadRequestMessage.cs` — NEW
+  - `BitPantry.CommandLine.Remote.SignalR/Envelopes/ClientFileEnumerateRequestMessage.cs` — NEW
+  - `BitPantry.CommandLine.Remote.SignalR/Envelopes/ClientFileAccessResponseMessage.cs` — NEW
+- **Spec reference:** See `specs/012-client-file-access/spec.md`
+- **Plan reference:** See `specs/012-client-file-access/plan.md`
+- **Data model reference:** See `specs/012-client-file-access/data-model.md`
+
+## Requirements
+
+- [ ] `PushMessageType` enum has `ClientFileUploadRequest` value
+- [ ] `PushMessageType` enum has `ClientFileDownloadRequest` value
+- [ ] `PushMessageType` enum has `ClientFileEnumerateRequest` value
+- [ ] `ServerRequestType` enum has `ClientFileAccessResponse` value (value = 6)
+- [ ] `ClientFileUploadRequestMessage` extends `PushMessage` with `ClientPath` and `ServerTempPath` properties
+- [ ] `ClientFileDownloadRequestMessage` extends `PushMessage` with `ServerPath`, `ClientPath`, and `FileSize` properties
+- [ ] `ClientFileEnumerateRequestMessage` extends `PushMessage` with `GlobPattern` property
+- [ ] `ClientFileAccessResponseMessage` extends `ServerRequest` with `Success`, `Error`, and `FileInfoEntries` properties
+- [ ] All message classes follow existing `MessageBase` pattern (Dictionary<string, string> data, JsonConstructor, typed property accessors)
+- [ ] All message classes have `CorrelationId` (inherited from `MessageBase`)
+
+## Prerequisites
+
+No prerequisites — this issue can be started independently.
+
+## Implementation Guidance
+
+Follow the exact pattern of existing message classes. For example, `FileUploadProgressMessage` shows how to extend `PushMessage`:
+
+```csharp
+public class ClientFileUploadRequestMessage : PushMessage
+{
+    [JsonIgnore]
+    public string ClientPath
+    {
+        get { return TryGetValue(MessageArgNames.ClientFileAccess.ClientPath); }
+        set { Data[MessageArgNames.ClientFileAccess.ClientPath] = value; }
+    }
+
+    [JsonIgnore]
+    public string ServerTempPath
+    {
+        get { return TryGetValue(MessageArgNames.ClientFileAccess.ServerTempPath); }
+        set { Data[MessageArgNames.ClientFileAccess.ServerTempPath] = value; }
+    }
+
+    [JsonConstructor]
+    public ClientFileUploadRequestMessage(Dictionary<string, string> data) : base(data) { }
+
+    public ClientFileUploadRequestMessage(string clientPath, string serverTempPath)
+        : base(PushMessageType.ClientFileUploadRequest)
+    {
+        ClientPath = clientPath;
+        ServerTempPath = serverTempPath;
+    }
+}
+```
+
+Add compact key names to `MessageArgNames` (e.g., `"cfacp"` for ClientPath, `"cfastp"` for ServerTempPath) following the existing pattern of abbreviated keys.
+
+For `ClientFileAccessResponseMessage`, extend `ServerRequest` (not `PushMessage`) since it flows client → server via `ReceiveRequest`. `FileInfoEntries` should be serialized/deserialized as JSON string (using `SerializeObject`/`DeserializeObject` helpers from `MessageBase`).
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Unit
+- **Test project:** `BitPantry.CommandLine.Tests.Remote.SignalR`
+- **Existing fixtures to reuse:** None — these are pure serialization tests
+
+### Prescribed Test Cases
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `ClientFileUploadRequestMessage_Roundtrip_PropertiesPreserved` | Create message, serialize to dict, deserialize from dict | All properties match original values |
+| 2 | `ClientFileDownloadRequestMessage_Roundtrip_PropertiesPreserved` | Same roundtrip test | All properties preserved |
+| 3 | `ClientFileEnumerateRequestMessage_Roundtrip_PropertiesPreserved` | Same roundtrip test | All properties preserved |
+| 4 | `ClientFileAccessResponseMessage_Roundtrip_PropertiesPreserved` | Same roundtrip test including FileInfoEntries JSON | All properties preserved |
+| 5 | `ClientFileAccessResponseMessage_WithError_ErrorPreserved` | Create with error string | Error property roundtrips correctly |
+| 6 | `ClientFileUploadRequestMessage_CorrelationId_Inherited` | Create message | Has non-null CorrelationId from base |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor.

--- a/specs/012-client-file-access/issues/003-remote-client-file-access.md
+++ b/specs/012-client-file-access/issues/003-remote-client-file-access.md
@@ -1,0 +1,156 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 003
+  GitHub Issue Number: #53
+-->
+
+# RemoteClientFileAccess server implementation
+
+**Labels**: enhancement, spec-012
+**Blocked by**: 001, 002
+**Implements**: FR-006, FR-007, FR-016, FR-017, FR-018, FR-025
+**Covers**: US-001, US-002, US-006
+
+## Summary
+
+Implement `RemoteClientFileAccess` — the server-side `IClientFileAccess` that coordinates file transfers between server and client via SignalR push messages and existing HTTP endpoints. Also wire up the hub routing for client responses and register the service in server DI.
+
+## Current Behavior
+
+Server-side commands have no way to programmatically access files on the client machine. The only file transfer mechanism is the user-initiated `server upload` / `server download` commands.
+
+## Expected Behavior
+
+Server-side commands can inject `IClientFileAccess` and call `GetFileAsync` / `SaveFileAsync`. The `RemoteClientFileAccess` implementation sends push messages to the client, awaits file transfer completion via `RpcMessageRegistry` correlation, and manages temp file staging in the sandbox. The hub routes `ClientFileAccessResponse` messages to the `RpcMessageRegistry`.
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine.Remote.SignalR.Server`
+- **Key files:**
+  - `BitPantry.CommandLine.Remote.SignalR.Server/ClientFileAccess/RemoteClientFileAccess.cs` — NEW
+  - `BitPantry.CommandLine.Remote.SignalR.Server/Configuration/IServiceCollectionExtensions.cs` — MODIFY: register scoped IClientFileAccess
+  - `BitPantry.CommandLine.Remote.SignalR.Server/CommandLineHub.cs` — MODIFY: add ClientFileAccessResponse routing
+- **Spec reference:** See `specs/012-client-file-access/spec.md`
+- **Plan reference:** See `specs/012-client-file-access/plan.md`
+
+## Requirements
+
+- [ ] `RemoteClientFileAccess` implements `IClientFileAccess` (FR-006)
+- [ ] `GetFileAsync` sends `ClientFileUploadRequest` push message via `HubInvocationContext.ClientProxy` and awaits response via `RpcMessageRegistry` (FR-006, FR-017)
+- [ ] `GetFileAsync` returns a `ClientFile` wrapping the uploaded temp file, with cleanup that deletes the temp file on dispose (FR-007)
+- [ ] `SaveFileAsync(Stream, ...)` writes stream to staging temp file, sends `ClientFileDownloadRequest`, awaits completion, deletes temp (FR-006, FR-016)
+- [ ] `SaveFileAsync(string, ...)` sends `ClientFileDownloadRequest` referencing the source path directly — no temp copy needed (FR-006, FR-016)
+- [ ] Both save methods support the stream and path overloads (FR-003, FR-004)
+- [ ] `GetFileAsync` supports fire-and-forget usage — returns `Task<ClientFile>` that can be awaited later (FR-018)
+- [ ] Files exceeding `MaxFileSizeBytes` are rejected with a clear error before transfer starts (FR-025)
+- [ ] Progress is reported via optional `IProgress<FileTransferProgress>` if provided (FR-019, implied)
+- [ ] `CommandLineHub.ReceiveRequest` routes `ServerRequestType.ClientFileAccessResponse` to `RpcMessageRegistry.SetResponse()` (FR-006)
+- [ ] `RemoteClientFileAccess` is registered as scoped `IClientFileAccess` in server DI, overriding the default local implementation (FR-006)
+- [ ] Staging temp files are written to `.client-file-staging/` within the sandbox (FR-006)
+- [ ] Staging temp files are cleaned up on both success and failure (FR-007)
+
+## Prerequisites
+
+- Blocked by: 001 — `IClientFileAccess` interface and `ClientFile` must exist
+- Blocked by: 002 — Protocol message envelopes must exist
+
+## Implementation Guidance
+
+### RemoteClientFileAccess Dependencies
+
+Inject via constructor:
+- `HubInvocationContext` — to access `Current.ClientProxy` for sending push messages and `Current.RpcMessageRegistry` for correlation
+- `IFileSystem` — sandboxed file system for staging temp files
+- `FileTransferOptions` — for `MaxFileSizeBytes` and `StorageRootPath`
+- `ILogger<RemoteClientFileAccess>`
+
+### GetFileAsync Flow
+
+```csharp
+public async Task<ClientFile> GetFileAsync(string clientPath, IProgress<FileTransferProgress>? progress, CancellationToken ct)
+{
+    var ctx = _hubInvocationContext.Current ?? throw new InvalidOperationException("No hub invocation context");
+    
+    var tempPath = Path.Combine(".client-file-staging", $"{Guid.NewGuid():N}");
+    _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
+    
+    var rpcCtx = ctx.RpcMessageRegistry.Register();
+    
+    var msg = new ClientFileUploadRequestMessage(clientPath, tempPath);
+    msg.CorrelationId = rpcCtx.CorrelationId;
+    await ctx.ClientProxy.SendAsync(SignalRMethodNames.ReceiveMessage, msg, ct);
+    
+    var response = await rpcCtx.WaitForCompletion<ClientFileAccessResponseMessage>();
+    if (!response.Success)
+        throw MapError(response.Error, clientPath);
+    
+    var fileInfo = _fileSystem.FileInfo.New(tempPath);
+    var stream = _fileSystem.File.OpenRead(tempPath);
+    
+    return new ClientFile(stream, Path.GetFileName(clientPath), fileInfo.Length,
+        async () => { if (_fileSystem.File.Exists(tempPath)) _fileSystem.File.Delete(tempPath); });
+}
+```
+
+### Hub Routing
+
+In `CommandLineHub.ReceiveRequest()`, add:
+```csharp
+case ServerRequestType.ClientFileAccessResponse:
+    _rpcMsgReg.SetResponse(req);
+    break;
+```
+
+### DI Registration
+
+In `IServiceCollectionExtensions.cs`:
+```csharp
+services.AddScoped<IClientFileAccess, RemoteClientFileAccess>();
+```
+
+This overrides the default `LocalClientFileAccess` singleton for server-side command execution scope.
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Unit (mocked hub context, RPC registry, file system)
+- **Test project:** `BitPantry.CommandLine.Tests.Remote.SignalR`
+- **Existing fixtures to reuse:** `MockFileSystem`, `Mock<IClientProxy>` (Moq)
+
+### Prescribed Test Cases
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `GetFileAsync_SendsPushMessage_WithCorrectClientPath` | Call GetFileAsync | Push message sent to ClientProxy with correct ClientPath |
+| 2 | `GetFileAsync_SuccessfulUpload_ReturnsClientFileWithStream` | Simulate successful response | Returns ClientFile with readable stream from temp file |
+| 3 | `GetFileAsync_ClientError_ThrowsException` | Simulate error response | Throws appropriate exception, temp file cleaned up |
+| 4 | `GetFileAsync_Dispose_DeletesTempFile` | Get file, dispose ClientFile | Temp file deleted from staging |
+| 5 | `SaveFileAsync_Stream_WritesTempAndSendsPush` | Save a stream | Temp file written, push message sent with correct paths |
+| 6 | `SaveFileAsync_Stream_SuccessfulDownload_DeletesTemp` | Simulate successful response | Staging temp file cleaned up |
+| 7 | `SaveFileAsync_Path_SendsPushWithSourcePath` | Save from source path | Push message references source directly (no temp copy) |
+| 8 | `SaveFileAsync_ExceedsMaxFileSize_ThrowsBeforeTransfer` | Source file exceeds MaxFileSizeBytes | Exception thrown, no push message sent |
+| 9 | `GetFileAsync_NoHubContext_ThrowsInvalidOperation` | Call outside hub invocation | Throws `InvalidOperationException` |
+| 10 | `GetFileAsync_CancellationRequested_ThrowsOperationCanceled` | Cancel during await | Throws `OperationCanceledException` |
+| 11 | `HubReceiveRequest_ClientFileAccessResponse_SetsRpcResponse` | Client sends response | RpcMessageRegistry.SetResponse called with correct correlation |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor.

--- a/specs/012-client-file-access/issues/004-consent-policy-and-allow-path.md
+++ b/specs/012-client-file-access/issues/004-consent-policy-and-allow-path.md
@@ -1,0 +1,152 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 004
+  GitHub Issue Number: #54
+-->
+
+# File access consent policy and ConnectCommand --allow-path
+
+**Labels**: enhancement, spec-012
+**Blocked by**: None
+**Implements**: FR-009, FR-011
+**Covers**: US-004
+
+## Summary
+
+Implement `FileAccessConsentPolicy` — the client-side rule engine that determines whether a server-initiated file access request requires user consent based on `--allow-path` patterns configured at connect time. Also extend `ConnectCommand` with the `--allow-path` argument and store the patterns in the consent policy.
+
+## Current Behavior
+
+`ConnectCommand` has arguments for `Uri`, `ApiKey`, `TokenRequestEndpoint`, `ProfileName`, and `Force`. There is no mechanism for the user to pre-approve file access paths. No consent policy infrastructure exists.
+
+## Expected Behavior
+
+`ConnectCommand` accepts one or more `--allow-path` arguments (glob patterns). After connection, these patterns are stored in `FileAccessConsentPolicy`. The policy can evaluate any path against the allowed patterns: paths matching an allowed pattern don't require consent; all other paths require a prompt. With no allowed paths configured, every path requires consent.
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine.Remote.SignalR.Client`
+- **Key files:**
+  - `BitPantry.CommandLine.Remote.SignalR.Client/FileAccessConsentPolicy.cs` — NEW
+  - `BitPantry.CommandLine.Remote.SignalR.Client/Commands/Server/ConnectCommand.cs` — MODIFY: add --allow-path argument
+  - `BitPantry.CommandLine.Remote.SignalR.Client/CommandLineApplicationBuilderExtensions.cs` — MODIFY: register policy in DI
+- **Spec reference:** See `specs/012-client-file-access/spec.md`
+- **Plan reference:** See `specs/012-client-file-access/plan.md`
+
+## Requirements
+
+- [ ] `FileAccessConsentPolicy` exists with `IsAllowed(string path)` method returning `bool` (FR-011)
+- [ ] `FileAccessConsentPolicy` exists with `RequiresConsent(string path)` returning `!IsAllowed(path)` (FR-009)
+- [ ] `FileAccessConsentPolicy` has `SetAllowedPatterns(IEnumerable<string> patterns)` to configure patterns (FR-011)
+- [ ] When no patterns are configured, `IsAllowed` returns `false` for all paths (FR-009)
+- [ ] Glob patterns with `*`, `**`, and `?` wildcards are supported (FR-011)
+- [ ] Pattern matching is case-insensitive on Windows (FR-011)
+- [ ] `ConnectCommand` has `--allow-path` / `-a` argument that accepts multiple values (FR-011)
+- [ ] After successful connection, `ConnectCommand` stores allowed paths in `FileAccessConsentPolicy` (FR-011)
+- [ ] `FileAccessConsentPolicy` is registered as singleton in client DI (FR-011)
+
+## Prerequisites
+
+No prerequisites — this issue can be started independently.
+
+## Implementation Guidance
+
+### FileAccessConsentPolicy
+
+```csharp
+public class FileAccessConsentPolicy
+{
+    private readonly List<string> _allowedPatterns = new();
+
+    public void SetAllowedPatterns(IEnumerable<string> patterns)
+    {
+        _allowedPatterns.Clear();
+        _allowedPatterns.AddRange(patterns);
+    }
+
+    public bool IsAllowed(string path)
+    {
+        if (_allowedPatterns.Count == 0) return false;
+        // Use Matcher from Microsoft.Extensions.FileSystemGlobbing
+        // or GlobPatternHelper for consistency
+        return _allowedPatterns.Any(pattern => MatchesPattern(path, pattern));
+    }
+
+    public bool RequiresConsent(string path) => !IsAllowed(path);
+
+    public IReadOnlyList<string> GetPathsRequiringConsent(IEnumerable<string> paths)
+        => paths.Where(RequiresConsent).ToList();
+}
+```
+
+For pattern matching, consider reusing `GlobPatternHelper.GlobPatternToRegex()` to convert each allowed pattern to a regex and match against the full path. This is consistent with how glob matching works elsewhere in the codebase.
+
+### ConnectCommand Extension
+
+Add to the existing arguments:
+
+```csharp
+[Argument(Name = "allow-path")]
+[Alias('a')]
+[Rest]  // collects multiple values: --allow-path c:\data\** --allow-path c:\backups\**
+[Description("Client paths the server may access without prompting (glob patterns)")]
+public string[] AllowPaths { get; set; }
+```
+
+After successful connection (at end of `Execute`), store in the policy:
+
+```csharp
+_consentPolicy.SetAllowedPatterns(AllowPaths ?? Array.Empty<string>());
+```
+
+### DI
+
+```csharp
+builder.Services.AddSingleton<FileAccessConsentPolicy>();
+```
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Unit (pure logic, no mocks needed for policy; ConnectCommand tested via integration later)
+- **Test project:** `BitPantry.CommandLine.Tests.Remote.SignalR`
+- **Existing fixtures to reuse:** None — pure unit tests
+
+### Prescribed Test Cases
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `IsAllowed_NoPatterns_ReturnsFalse` | No patterns configured | Returns `false` for any path |
+| 2 | `IsAllowed_ExactMatch_ReturnsTrue` | Pattern is `c:\data\file.txt`, path is same | Returns `true` |
+| 3 | `IsAllowed_StarGlob_MatchesFiles` | Pattern `c:\data\*`, path `c:\data\file.txt` | Returns `true` |
+| 4 | `IsAllowed_DoubleStarGlob_MatchesRecursive` | Pattern `c:\data\**`, path `c:\data\sub\deep\file.txt` | Returns `true` |
+| 5 | `IsAllowed_QuestionMark_MatchesSingleChar` | Pattern `file?.txt`, path `file1.txt` | Returns `true` |
+| 6 | `IsAllowed_NonMatchingPath_ReturnsFalse` | Pattern `c:\data\**`, path `c:\secrets\pw.txt` | Returns `false` |
+| 7 | `IsAllowed_CaseInsensitive_Windows` | Pattern `C:\Data\**`, path `c:\data\file.txt` | Returns `true` (on Windows) |
+| 8 | `RequiresConsent_AllowedPath_ReturnsFalse` | Path is allowed | `RequiresConsent` returns `false` |
+| 9 | `RequiresConsent_UnallowedPath_ReturnsTrue` | Path not in allowed | `RequiresConsent` returns `true` |
+| 10 | `SetAllowedPatterns_ReplacesExisting` | Set patterns, then set new ones | Only new patterns apply |
+| 11 | `GetPathsRequiringConsent_MixedPaths_ReturnsOnlyUnapproved` | Some paths allowed, some not | Returns only the unapproved paths |
+| 12 | `IsAllowed_MultiplePatterns_AnyMatch_ReturnsTrue` | Two patterns, path matches second | Returns `true` |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor.

--- a/specs/012-client-file-access/issues/005-client-handler-and-consent-ux.md
+++ b/specs/012-client-file-access/issues/005-client-handler-and-consent-ux.md
@@ -1,0 +1,206 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 005
+  GitHub Issue Number: #55
+-->
+
+# Client-side push message handler and consent UX
+
+**Labels**: enhancement, spec-012
+**Blocked by**: 002, 004
+**Implements**: FR-009, FR-010, FR-012, FR-013, FR-014, FR-020
+**Covers**: US-004, US-005
+
+## Summary
+
+Extend the client's `SignalRServerProxy.ReceiveMessage()` to handle the three new push message types (`ClientFileUploadRequest`, `ClientFileDownloadRequest`, `ClientFileEnumerateRequest`). Implement `FileAccessConsentHandler` — the UX component that pauses console output, renders a visually distinct consent prompt, reads the user's response, resumes output, and then performs the actual file transfer using the existing `FileTransferService`.
+
+## Current Behavior
+
+`SignalRServerProxy.ReceiveMessage()` only handles `PushMessageType.FileUploadProgress`. There is no mechanism for the server to request file operations from the client, no consent prompt infrastructure, and no console output buffering during prompts.
+
+## Expected Behavior
+
+When the server sends a file access request push message, the client:
+1. Evaluates the path against `FileAccessConsentPolicy`
+2. If consent required: pauses console output, renders a Spectre.Console `Panel` prompt showing the actual path, reads Y/N, clears prompt, resumes output
+3. If approved (or pre-allowed): performs the file transfer using existing `FileTransferService.UploadFile()` or `DownloadFile()`
+4. Sends a `ClientFileAccessResponse` back to the server with success/error
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine.Remote.SignalR.Client`
+- **Key files:**
+  - `BitPantry.CommandLine.Remote.SignalR.Client/FileAccessConsentHandler.cs` — NEW
+  - `BitPantry.CommandLine.Remote.SignalR.Client/SignalRServerProxy.cs` — MODIFY: add cases in ReceiveMessage, add console output buffering
+  - `BitPantry.CommandLine.Remote.SignalR.Client/CommandLineApplicationBuilderExtensions.cs` — MODIFY: register consent handler
+- **Spec reference:** See `specs/012-client-file-access/spec.md`
+- **Plan reference:** See `specs/012-client-file-access/plan.md`
+
+## Requirements
+
+- [ ] `ReceiveMessage` handles `PushMessageType.ClientFileUploadRequest` — evaluates consent, uploads file to server if approved, sends response (FR-009)
+- [ ] `ReceiveMessage` handles `PushMessageType.ClientFileDownloadRequest` — evaluates consent, downloads file from server if approved, sends response (FR-009)
+- [ ] `ReceiveMessage` handles `PushMessageType.ClientFileEnumerateRequest` — evaluates consent (batch), expands glob, sends file list response (FR-009)
+- [ ] Consent prompt is rendered client-side showing the actual requested path — server does not control prompt text (FR-010)
+- [ ] Consent prompt uses a visually distinct Spectre.Console `Panel` with colored border (FR-013)
+- [ ] Console output from the server is buffered (paused) while consent prompt is active (FR-012)
+- [ ] Buffered console output is flushed in order after the prompt is dismissed (FR-012)
+- [ ] When user denies consent, response to server indicates access denied (FR-014)
+- [ ] When user denies consent, no file data is transferred (FR-014)
+- [ ] File transfers use existing `FileTransferService.UploadFile()` and `DownloadFile()` (FR-016, FR-017)
+- [ ] Partial files on client are cleaned up on download failure (FR-020)
+- [ ] Client sends `ServerRequest(ClientFileAccessResponse)` back via `ReceiveRequest` channel after operation completes
+- [ ] `FileAccessConsentHandler` is registered as singleton in client DI
+- [ ] Multiple concurrent consent requests are serialized — only one prompt displays at a time
+
+## Prerequisites
+
+- Blocked by: 002 — Protocol message envelopes must exist
+- Blocked by: 004 — `FileAccessConsentPolicy` must exist for consent evaluation
+
+## Implementation Guidance
+
+### Console Output Buffering
+
+Add to `SignalRServerProxy`:
+
+```csharp
+private volatile bool _consoleOutputPaused;
+private readonly ConcurrentQueue<string> _bufferedConsoleOutput = new();
+
+private void ConsoleOut(string str)
+{
+    if (_consoleOutputPaused)
+        _bufferedConsoleOutput.Enqueue(str);
+    else
+        _console.Profile.Out.Writer.Write(str);
+}
+
+private void FlushBufferedOutput()
+{
+    while (_bufferedConsoleOutput.TryDequeue(out var output))
+        _console.Profile.Out.Writer.Write(output);
+}
+```
+
+### FileAccessConsentHandler
+
+```csharp
+public class FileAccessConsentHandler
+{
+    private readonly FileAccessConsentPolicy _policy;
+    private readonly IAnsiConsole _console;
+    private readonly SemaphoreSlim _promptLock = new(1, 1); // serialize prompts
+
+    public async Task<bool> RequestConsentAsync(string path, Action pauseOutput, Action resumeOutput, CancellationToken ct)
+    {
+        if (_policy.IsAllowed(path)) return true;
+
+        await _promptLock.WaitAsync(ct);
+        try
+        {
+            pauseOutput();
+            await Task.Delay(50, ct); // let in-flight output arrive
+
+            var panel = new Panel($"Server requests: [bold]{Markup.Escape(path)}[/]\nAllow? [green]y[/]/[red]N[/]")
+                .Header("File Access Request")
+                .BorderColor(Color.Yellow);
+            _console.Write(panel);
+
+            var key = _console.Input.ReadKey(intercept: true);
+            var allowed = key?.Key == ConsoleKey.Y;
+
+            // Clear prompt lines via ANSI
+            // ... cursor-up + clear-line for panel height ...
+
+            resumeOutput();
+            return allowed;
+        }
+        finally
+        {
+            _promptLock.Release();
+        }
+    }
+}
+```
+
+### ReceiveMessage Extension
+
+```csharp
+case PushMessageType.ClientFileUploadRequest:
+    var uploadReq = new ClientFileUploadRequestMessage(msg.Data);
+    _ = Task.Run(async () =>
+    {
+        var approved = await _consentHandler.RequestConsentAsync(
+            uploadReq.ClientPath,
+            () => _consoleOutputPaused = true,
+            () => { _consoleOutputPaused = false; FlushBufferedOutput(); },
+            CancellationToken.None);
+
+        if (approved)
+        {
+            await _fileTransferService.UploadFile(
+                uploadReq.ClientPath, uploadReq.ServerTempPath,
+                progress => Task.CompletedTask, CancellationToken.None);
+            await SendFileAccessResponse(uploadReq.CorrelationId, success: true);
+        }
+        else
+        {
+            await SendFileAccessResponse(uploadReq.CorrelationId, success: false, error: "FileAccessDenied");
+        }
+    });
+    break;
+```
+
+Note: The handler runs on `Task.Run` (not blocking `ReceiveMessage`) — same pattern as `ReceiveRequest`.
+
+### Prompt Clearing
+
+Use `AnsiCodes.CursorUp(n)` + `AnsiCodes.ClearLine` (already in `BitPantry.CommandLine/AutoComplete/Rendering/AnsiCodes.cs`) to erase the panel after the user answers. Calculate panel height from the number of rendered lines.
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Unit + UX (VirtualConsole for prompt rendering)
+- **Test project:** `BitPantry.CommandLine.Tests.Remote.SignalR`
+- **Existing fixtures to reuse:** `VirtualConsole`, `VirtualConsoleAssertions`, `TestFileTransferServiceFactory`, `FileTransferServiceTestContext`
+
+### Prescribed Test Cases
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `RequestConsent_AllowedPath_ReturnsTrueNoPrompt` | Path is in allowed list | Returns true, no console output for prompt |
+| 2 | `RequestConsent_UnallowedPath_ShowsPrompt` | Path not allowed | Panel rendered with correct path text |
+| 3 | `RequestConsent_UserApprovesY_ReturnsTrue` | User presses Y | Returns true |
+| 4 | `RequestConsent_UserDeniesN_ReturnsFalse` | User presses N | Returns false |
+| 5 | `RequestConsent_DefaultDeny_ReturnsFalse` | User presses Enter (default N) | Returns false |
+| 6 | `RequestConsent_PromptVisuallyDistinct` | Prompt rendered | Output contains Panel border/markup |
+| 7 | `RequestConsent_OutputBufferedDuringPrompt` | Server output arrives during prompt | Output not rendered until after prompt dismissed |
+| 8 | `RequestConsent_BufferedOutputFlushedAfter` | Prompt dismissed | All buffered output appears in correct order |
+| 9 | `ReceiveMessage_UploadRequest_Approved_UploadsFile` | Approve consent for upload request | `FileTransferService.UploadFile` called with correct paths |
+| 10 | `ReceiveMessage_DownloadRequest_Approved_DownloadsFile` | Approve consent for download request | `FileTransferService.DownloadFile` called with correct paths |
+| 11 | `ReceiveMessage_UploadRequest_Denied_SendsAccessDenied` | Deny consent | Response sent with success=false, error=FileAccessDenied |
+| 12 | `ReceiveMessage_ConcurrentRequests_Serialized` | Two requests arrive simultaneously | Prompts shown one at a time (not interleaved) |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor.

--- a/specs/012-client-file-access/issues/006-integration-single-file.md
+++ b/specs/012-client-file-access/issues/006-integration-single-file.md
@@ -1,0 +1,204 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 006
+  GitHub Issue Number: #56
+-->
+
+# End-to-end integration: single file GetFile and SaveFile
+
+**Labels**: enhancement, spec-012
+**Blocked by**: 003, 005
+**Implements**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-008, FR-009, FR-010, FR-015, FR-016, FR-017
+**Covers**: US-001, US-002, US-003, US-004, US-005, US-006
+
+## Summary
+
+Validate the complete round-trip for single-file `GetFileAsync` and `SaveFileAsync` operations through integration tests using `TestEnvironment`. This issue is primarily about proving the end-to-end flow works by writing integration tests with purpose-built test commands and fixing any issues discovered during integration. No major new production code should be needed — phases 1-3 (issues 001–005) provide all the pieces.
+
+## Current Behavior
+
+Issues 001–005 provide all production code pieces: local implementation, protocol messages, server implementation, client handler, and consent infrastructure. However, the full round-trip has not been validated through real client/server interaction.
+
+## Expected Behavior
+
+Integration tests prove that:
+- A server-side command can save a file to the client and the file appears on disk
+- A server-side command can read a file from the client and receives correct content
+- The same command works locally without a server
+- Consent prompts appear when paths aren't pre-allowed
+- Consent denial prevents file transfer
+- Console output buffering works during concurrent output + consent
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine.Tests.Remote.SignalR`, potentially minor fixes to any of the production projects
+- **Key files:**
+  - `BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/ClientFileAccessIntegrationTests.cs` — NEW
+  - `BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/TestCommands/TestSaveFileCommand.cs` — NEW: test command registered on server
+  - `BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/TestCommands/TestGetFileCommand.cs` — NEW: test command registered on server
+  - `BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/TestCommands/TestStreamSaveCommand.cs` — NEW: test command for stream save
+- **Spec reference:** See `specs/012-client-file-access/spec.md`
+- **Plan reference:** See `specs/012-client-file-access/plan.md`
+
+## Requirements
+
+- [ ] Integration test proves server command saves file to client disk via `IClientFileAccess.SaveFileAsync(string, ...)` with `--allow-path` (US-001)
+- [ ] Integration test proves server command reads file from client disk via `IClientFileAccess.GetFileAsync` with `--allow-path` (US-002)
+- [ ] Integration test proves `SaveFileAsync(Stream, ...)` delivers in-memory content to client (US-006)
+- [ ] Integration test proves same command works locally (no server) for both get and save (US-003)
+- [ ] Integration test proves consent prompt appears on VirtualConsole when no `--allow-path` configured (US-004)
+- [ ] Integration test proves consent prompt shows correct path (not server-controlled text) (FR-010)
+- [ ] Integration test proves user denial prevents file transfer and server gets error (US-004, FR-014)
+- [ ] Integration test proves `--allow-path` bypasses consent prompt (FR-011)
+- [ ] Integration test proves console output is buffered during consent and resumes after (US-005, FR-012)
+- [ ] Integration test proves parent directories are created on client when saving (FR-008)
+- [ ] Integration test proves cancellation token cancels the operation (FR-015)
+- [ ] All integration tests use `TestEnvironment` with real in-memory ASP.NET TestServer
+
+## Prerequisites
+
+- Blocked by: 003 — `RemoteClientFileAccess` must be implemented
+- Blocked by: 005 — Client handler and consent UX must be implemented
+
+## Implementation Guidance
+
+### Test Commands
+
+Create simple test commands that are registered on the server via `TestEnvironment` server options. Each command injects `IClientFileAccess` and exercises one operation:
+
+```csharp
+[Command(Name = "test-save")]
+public class TestSaveFileCommand : CommandBase
+{
+    [Argument(Position = 0)]
+    public string SourcePath { get; set; }
+
+    [Argument(Position = 1)]
+    public string ClientPath { get; set; }
+
+    private readonly IClientFileAccess _clientFiles;
+
+    public TestSaveFileCommand(IClientFileAccess clientFiles) { _clientFiles = clientFiles; }
+
+    public async Task<int> ExecuteAsync(CommandExecutionContext ctx)
+    {
+        await _clientFiles.SaveFileAsync(SourcePath, ClientPath, ct: ctx.CancellationToken);
+        return 0;
+    }
+}
+```
+
+Register in test setup:
+```csharp
+using var env = new TestEnvironment(opt => opt.ConfigureServer(serverOpts =>
+{
+    serverOpts.RegisterCommand<TestSaveFileCommand>();
+    serverOpts.RegisterCommand<TestGetFileCommand>();
+}));
+```
+
+### Integration Test Pattern
+
+```csharp
+[TestMethod]
+public async Task SaveFile_RemoteCommand_FileAppearsOnClient()
+{
+    using var serverTemp = new TempDirectoryScope();
+    using var clientTemp = new TempDirectoryScope();
+
+    // Place source file on server
+    File.WriteAllText(Path.Combine(serverTemp.Path, "export.json"), "{\"data\": true}");
+
+    using var env = new TestEnvironment(opt => opt.ConfigureServer(serverOpts =>
+    {
+        serverOpts.StorageRoot = serverTemp.Path;
+        serverOpts.RegisterCommand<TestSaveFileCommand>();
+    }));
+
+    await env.ConnectToServerAsync(allowPaths: new[] { clientTemp.Path + "\\**" });
+    await env.RunCommandAsync($"test-save export.json {clientTemp.Path}\\export.json");
+
+    File.Exists(Path.Combine(clientTemp.Path, "export.json")).Should().BeTrue();
+    File.ReadAllText(Path.Combine(clientTemp.Path, "export.json")).Should().Be("{\"data\": true}");
+}
+```
+
+### Consent Test Pattern
+
+```csharp
+[TestMethod]
+public async Task GetFile_NoAllowPath_PromptsForConsent()
+{
+    using var clientTemp = new TempDirectoryScope();
+    File.WriteAllText(Path.Combine(clientTemp.Path, "data.csv"), "a,b,c");
+
+    using var env = new TestEnvironment(opt => opt.ConfigureServer(serverOpts =>
+    {
+        serverOpts.RegisterCommand<TestGetFileCommand>();
+    }));
+
+    await env.ConnectToServerAsync(); // no --allow-path
+
+    // The command will block waiting for consent. Simulate approval:
+    var commandTask = env.RunCommandAsync($"test-get {clientTemp.Path}\\data.csv");
+
+    // Wait for prompt to appear
+    await env.Console.WaitForText("File Access Request", timeout: 5000);
+    env.Console.VirtualConsole.Should().ContainText("data.csv");
+
+    // Approve
+    env.Keyboard.PressKey(ConsoleKey.Y);
+
+    await commandTask;
+    // Verify command succeeded (check pipeline result or temp marker)
+}
+```
+
+### Note on TestEnvironment Extensions
+
+Some tests may require extending `TestEnvironment` or `ConnectToServerAsync` to support `--allow-path`. If so, add an `allowPaths` parameter or use the `RunCommandAsync` approach to issue the connect command with the argument directly.
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Integration (TestEnvironment with real client/server)
+- **Test project:** `BitPantry.CommandLine.Tests.Remote.SignalR`
+- **Existing fixtures to reuse:** `TestEnvironment`, `VirtualConsole`, `VirtualConsoleAssertions`, `TempFileScope`, keyboard simulation
+
+### Prescribed Test Cases
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `SaveFile_RemoteCommand_FileAppearsOnClient` | Server command saves file via IClientFileAccess | File exists on client with correct content |
+| 2 | `GetFile_RemoteCommand_ReadsClientFile` | Server command reads file via IClientFileAccess | Command receives correct file content |
+| 3 | `SaveFile_Stream_ContentArrivesOnClient` | Server command saves MemoryStream | Content appears on client |
+| 4 | `SaveFile_LocalCommand_WritesDirectly` | Command runs locally, saves file | File written without server |
+| 5 | `GetFile_LocalCommand_ReadsDirectly` | Command runs locally, reads file | File read without server |
+| 6 | `GetFile_NoAllowPath_PromptsForConsent` | No --allow-path set | VirtualConsole shows consent panel |
+| 7 | `GetFile_AllowPathConfigured_NoPrompt` | --allow-path covers requested path | Transfer succeeds, no prompt shown |
+| 8 | `GetFile_UserDenies_CommandReceivesError` | User presses N at consent | Command gets FileAccessDeniedException |
+| 9 | `ConsentPrompt_DuringOutput_OutputBuffered` | Command streams output + requests file | Output pauses during prompt, resumes after |
+| 10 | `SaveFile_CreatesParentDirectories` | Destination parent doesn't exist | Parent dirs created, file saved |
+| 11 | `SaveFile_CancellationToken_CancelsOperation` | Cancel during transfer | OperationCanceledException |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above. Expect to find integration-level issues with timing, serialization, or DI scoping that unit tests didn't catch.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor. For integration issues, the RED phase may reveal needed fixes in issues 001–005's code.

--- a/specs/012-client-file-access/issues/007-glob-pattern-support.md
+++ b/specs/012-client-file-access/issues/007-glob-pattern-support.md
@@ -1,0 +1,208 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 007
+  GitHub Issue Number: #57
+-->
+
+# Glob pattern support: GetFilesAsync with lazy enumeration
+
+**Labels**: enhancement, spec-012
+**Blocked by**: 006
+**Implements**: FR-021, FR-022, FR-023, FR-024
+**Covers**: US-007
+
+## Summary
+
+Add `GetFilesAsync(string clientGlobPattern, ...)` to `IClientFileAccess` returning `IAsyncEnumerable<ClientFile>`. Files are transferred lazily — each file is uploaded from the client only when the server-side caller iterates to it. Glob expansion happens client-side (where the files are). Consent is batched — one prompt for the entire matched set.
+
+## Current Behavior
+
+`IClientFileAccess` supports single-file operations (`GetFileAsync`, `SaveFileAsync`). To process multiple files, a command would need to know the exact paths upfront and call `GetFileAsync` in a loop. There's no glob pattern expansion.
+
+## Expected Behavior
+
+Commands can call `await foreach (var file in _clientFiles.GetFilesAsync("**/*.csv")) { ... }` and receive files one at a time, lazily transferred. The client expands the glob pattern locally using the existing `GlobPatternHelper` + `FileSystemGlobbing` infrastructure, presents a batch consent prompt (if needed) with tiered display, and uploads each file on demand.
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine`, `BitPantry.CommandLine.Remote.SignalR.Server`, `BitPantry.CommandLine.Remote.SignalR.Client`
+- **Key files:**
+  - `BitPantry.CommandLine/Client/IClientFileAccess.cs` — MODIFY: add `GetFilesAsync`
+  - `BitPantry.CommandLine/Client/LocalClientFileAccess.cs` — MODIFY: implement local glob expansion
+  - `BitPantry.CommandLine.Remote.SignalR.Server/ClientFileAccess/RemoteClientFileAccess.cs` — MODIFY: implement remote glob flow
+  - `BitPantry.CommandLine.Remote.SignalR.Client/SignalRServerProxy.cs` — MODIFY: handle `ClientFileEnumerateRequest` in `ReceiveMessage`
+  - `BitPantry.CommandLine.Remote.SignalR.Client/FileAccessConsentHandler.cs` — MODIFY: add `RequestBatchConsentAsync` with tiered display
+- **Spec reference:** See `specs/012-client-file-access/spec.md`
+- **Plan reference:** See `specs/012-client-file-access/plan.md`
+
+## Requirements
+
+- [ ] `IClientFileAccess` has `GetFilesAsync(string clientGlobPattern, IProgress<FileTransferProgress>?, CancellationToken)` returning `IAsyncEnumerable<ClientFile>` (FR-021)
+- [ ] Files are transferred lazily — each file transfers when the caller iterates to it, not upfront (FR-021)
+- [ ] `LocalClientFileAccess.GetFilesAsync` expands glob locally using `Microsoft.Extensions.FileSystemGlobbing` (FR-024)
+- [ ] Local implementation applies `GlobPatternHelper.ApplyQuestionMarkFilter` for `?` wildcards (FR-022)
+- [ ] Remote implementation sends `ClientFileEnumerateRequest` to client, client expands glob locally (FR-023)
+- [ ] Remote implementation receives file list, then sends individual `ClientFileUploadRequest` per file as caller iterates (FR-023)
+- [ ] Client-side glob expansion reuses `GlobPatternHelper` infrastructure (FR-022)
+- [ ] Empty pattern result returns empty enumerable (not an error) (US-007 scenario 3)
+- [ ] Consent for glob is batched — one prompt for all matched files using tiered display (spec edge case)
+- [ ] Tiered consent display: ≤10 files show full list, 11–50 show collapsed (first 5 + last 2), >50 show summary only
+- [ ] Each yielded `ClientFile` is independently disposable (FR-021)
+
+## Prerequisites
+
+- Blocked by: 006 — Single-file round-trip must be working end-to-end
+
+## Implementation Guidance
+
+### IClientFileAccess Addition
+
+```csharp
+IAsyncEnumerable<ClientFile> GetFilesAsync(string clientGlobPattern, IProgress<FileTransferProgress>? progress = null, [EnumeratorCancellation] CancellationToken ct = default);
+```
+
+### LocalClientFileAccess Implementation
+
+Reuse the expansion logic from `UploadCommand.ExpandSource()`:
+
+```csharp
+public async IAsyncEnumerable<ClientFile> GetFilesAsync(string pattern, IProgress<FileTransferProgress>? progress, [EnumeratorCancellation] CancellationToken ct)
+{
+    var (baseDir, searchPattern) = GlobPatternHelper.ParseGlobPattern(pattern, _fileSystem);
+    var matcher = new Matcher();
+    matcher.AddInclude(searchPattern.Replace('?', '*'));
+    var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(baseDir)));
+
+    var files = result.Files
+        .Select(f => _fileSystem.Path.GetFullPath(Path.Combine(baseDir, f.Path)))
+        .ToList();
+    files = GlobPatternHelper.ApplyQuestionMarkFilter(files, searchPattern, Path.GetFileName).ToList();
+
+    foreach (var filePath in files)
+    {
+        ct.ThrowIfCancellationRequested();
+        yield return await GetFileAsync(filePath, progress, ct);
+    }
+}
+```
+
+### RemoteClientFileAccess Implementation
+
+```csharp
+public async IAsyncEnumerable<ClientFile> GetFilesAsync(string pattern, IProgress<FileTransferProgress>? progress, [EnumeratorCancellation] CancellationToken ct)
+{
+    // Step 1: Ask client to enumerate files matching pattern
+    var enumerateCtx = ctx.RpcMessageRegistry.Register();
+    var enumerateMsg = new ClientFileEnumerateRequestMessage(pattern) { CorrelationId = enumerateCtx.CorrelationId };
+    await ctx.ClientProxy.SendAsync(SignalRMethodNames.ReceiveMessage, enumerateMsg, ct);
+    var enumerateResp = await enumerateCtx.WaitForCompletion<ClientFileAccessResponseMessage>();
+
+    if (!enumerateResp.Success)
+        throw MapError(enumerateResp.Error, pattern);
+
+    var fileEntries = enumerateResp.DeserializeFileInfoEntries(); // [{Path, Size}, ...]
+
+    // Step 2: Lazy iteration — upload each file on demand
+    foreach (var entry in fileEntries)
+    {
+        ct.ThrowIfCancellationRequested();
+        yield return await GetFileAsync(entry.Path, progress, ct);
+    }
+}
+```
+
+Note: The individual `GetFileAsync` calls in step 2 skip consent — it was already granted in batch during the enumerate step. This may require a flag or separate internal method that bypasses consent.
+
+### Client Enumerate Handler
+
+In `ReceiveMessage`:
+```csharp
+case PushMessageType.ClientFileEnumerateRequest:
+    var enumReq = new ClientFileEnumerateRequestMessage(msg.Data);
+    _ = Task.Run(async () =>
+    {
+        // Expand glob locally
+        var files = ExpandGlobLocally(enumReq.GlobPattern);
+        
+        // Batch consent
+        var pathsNeedingConsent = _consentPolicy.GetPathsRequiringConsent(files.Select(f => f.Path));
+        if (pathsNeedingConsent.Count > 0)
+        {
+            var approved = await _consentHandler.RequestBatchConsentAsync(
+                pathsNeedingConsent, files.Select(f => f.Size).ToList(),
+                enumReq.GlobPattern, ...);
+            if (!approved)
+            {
+                await SendFileAccessResponse(enumReq.CorrelationId, false, "FileAccessDenied");
+                return;
+            }
+        }
+
+        await SendFileAccessResponse(enumReq.CorrelationId, true, fileInfoEntries: files);
+    });
+    break;
+```
+
+### Tiered Batch Consent Display
+
+In `FileAccessConsentHandler.RequestBatchConsentAsync`:
+- ≤ `ConsentFullListThreshold` (10): List all files with sizes
+- ≤ `ConsentSummaryOnlyThreshold` (50): Show first `ConsentCollapsedHeadCount` (5) + last `ConsentCollapsedTailCount` (2) + "... and N more (total: X MB)"
+- \> 50: Summary only — count, pattern, total size, base directory
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Unit + Integration
+- **Test project:** `BitPantry.CommandLine.Tests` (local), `BitPantry.CommandLine.Tests.Remote.SignalR` (remote + integration)
+- **Existing fixtures to reuse:** `MockFileSystem`, `TestEnvironment`, `VirtualConsole`, `GlobPatternHelper`
+
+### Prescribed Test Cases
+
+**Unit — Local:**
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `GetFilesAsync_StarGlob_ReturnsMatchingFiles` | `*.csv` matches 2 of 3 files | Yields 2 ClientFile instances |
+| 2 | `GetFilesAsync_DoubleStarGlob_MatchesRecursive` | `**/*.log` in nested dirs | All matching files returned |
+| 3 | `GetFilesAsync_NoMatches_ReturnsEmpty` | Pattern matches nothing | Empty enumerable, no error |
+| 4 | `GetFilesAsync_QuestionMark_MatchesSingleChar` | `file?.txt` | Only single-char matches |
+| 5 | `GetFilesAsync_LazyEnumeration_OpensFilesOnDemand` | Iterate only first 2 of 5 | Only 2 FileStreams opened |
+
+**Unit — Remote (mocked):**
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 6 | `GetFilesAsync_SendsEnumerateRequest` | Call GetFilesAsync | Push message sent with glob pattern |
+| 7 | `GetFilesAsync_ClientDenies_ThrowsAccessDenied` | Enumerate response denied | Throws FileAccessDeniedException |
+
+**Integration (TestEnvironment):**
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 8 | `GetFiles_GlobPattern_AllMatchesReturned` | 3 matching + 1 non-matching | Command receives exactly 3 files |
+| 9 | `GetFiles_LazyEnumeration_TransfersPerIteration` | Consume only first 2 of 5 | Only 2 uploads occurred |
+| 10 | `GetFiles_BatchConsent_ShowsFileList` | No --allow-path, ≤10 files | Consent panel shows all file paths |
+| 11 | `GetFiles_BatchConsent_LargeSet_ShowsSummary` | >50 files matching | Consent panel shows count + total size, not all filenames |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor.

--- a/specs/012-client-file-access/issues/008-edge-cases-hardening.md
+++ b/specs/012-client-file-access/issues/008-edge-cases-hardening.md
@@ -1,0 +1,169 @@
+<!--
+  STAGED ISSUE — not yet published to GitHub.
+  Use /publish-issues to create this issue on GitHub.
+  
+  Staging Number: 008
+  GitHub Issue Number: #58
+-->
+
+# Edge cases and hardening
+
+**Labels**: enhancement, spec-012
+**Blocked by**: 006, 007
+**Implements**: FR-020, FR-025
+**Covers**: All user stories (hardening)
+
+> Also addresses the 12 prose edge cases defined in `spec.md`.
+
+## Summary
+
+Harden the client file access system against edge cases: client disconnect during transfer, partial file cleanup, MaxFileSizeBytes enforcement, FileNotFoundException propagation, concurrent consent prompt serialization, path traversal validation, and large stream handling.
+
+## Current Behavior
+
+After issues 001–007, the happy-path behaviors work. This issue covers the edge cases and error conditions defined in the spec.
+
+## Expected Behavior
+
+All edge-case scenarios from `spec.md` EC-001 through EC-012 are handled gracefully with appropriate errors, cleanup, and no resource leaks.
+
+## Affected Area
+
+- **Project(s):** `BitPantry.CommandLine`, `BitPantry.CommandLine.Remote.SignalR.Server`, `BitPantry.CommandLine.Remote.SignalR.Client`
+- **Key files:**
+  - `RemoteClientFileAccess.cs` — MODIFY: disconnect handling, timeout, size limit enforcement
+  - `SignalRServerProxy.cs` / ReceiveMessage handler — MODIFY: partial file cleanup on failure
+  - `FileAccessConsentHandler.cs` — MODIFY: concurrent prompt serialization
+  - `FileTransferService.cs` — MODIFY: MaxFileSizeBytes enforcement, stream size validation
+  - `ClientFile.cs` — MODIFY: ensure proper Dispose cleans up temp files
+- **Spec reference:** See `specs/012-client-file-access/spec.md` (Edge Cases section)
+- **Plan reference:** See `specs/012-client-file-access/plan.md` (Phase 5)
+
+## Requirements
+
+- [ ] Client disconnect during GetFileAsync → `RemoteClientFileAccess` throws `RemoteMessagingException` / `TaskCanceledException`, no temp file left behind (EC-001)
+- [ ] Client disconnect during SaveFileAsync → partial file cleaned up on server or client depending on direction (EC-002)
+- [ ] Partial file cleanup: if transfer fails mid-stream, any partially-written temp file is deleted (EC-003)
+- [ ] MaxFileSizeBytes exceeded → `InvalidOperationException` with size details, transfer aborted early (EC-004)
+- [ ] FileNotFoundException on client for GetFileAsync → propagated to server as `FileNotFoundException` (EC-005)
+- [ ] FileNotFoundException on client for SaveFileAsync → propagated appropriately (path doesn't exist) (EC-006)
+- [ ] Path traversal in glob pattern → rejected before expansion (EC-007)
+- [ ] Concurrent GetFileAsync calls from same command → prompts serialized, not interleaved (EC-008)
+- [ ] CancellationToken honored at every async boundary (EC-009)
+- [ ] ClientFile.Dispose cleans up temp stream and file if applicable (EC-010)
+- [ ] Empty file (0 bytes) transfers correctly for both GetFile and SaveFile (EC-011)
+- [ ] Very large file (>MaxFileSizeBytes if configured) rejected before transfer starts (EC-012)
+- [ ] ClientFile does not throw on finalizer if not disposed (MAY log warning, MUST NOT crash) (spec edge case #4)
+
+## Prerequisites
+
+- Blocked by: 006, 007 — Happy-path single-file and glob must work first
+
+## Implementation Guidance
+
+### Client Disconnect Handling (EC-001, EC-002)
+
+The existing `RpcMessageRegistry.WaitForCompletion` has a timeout mechanism. Ensure:
+1. `RemoteClientFileAccess.GetFileAsync` wraps the await in try/catch for `OperationCanceledException` and `HubException`
+2. On failure, check if a temp file was created and delete it
+3. `SaveFileAsync` server-side failure should trigger client cleanup of the partially-downloaded file
+
+### Partial File Cleanup (EC-003)
+
+```csharp
+// In client handler for file upload:
+string? tempPath = null;
+try
+{
+    tempPath = GetTempFilePath();
+    await DownloadToTempFile(url, tempPath, ct);
+    // ... send response
+}
+catch
+{
+    if (tempPath != null && _fileSystem.File.Exists(tempPath))
+        _fileSystem.File.Delete(tempPath);
+    throw;
+}
+```
+
+### MaxFileSizeBytes Enforcement (EC-004, EC-012)
+
+Check file size before initiating transfer:
+```csharp
+if (_options.MaxFileSizeBytes > 0 && fileInfo.Length > _options.MaxFileSizeBytes)
+    throw new InvalidOperationException($"File '{path}' ({fileInfo.Length:N0} bytes) exceeds maximum allowed size ({_options.MaxFileSizeBytes:N0} bytes).");
+```
+
+For server→client downloads (SaveFile), the server knows the size upfront and includes it in the message. The client validates before downloading.
+
+### Concurrent Prompt Serialization (EC-008)
+
+```csharp
+private readonly SemaphoreSlim _consentSemaphore = new(1, 1);
+
+public async Task<bool> RequestConsentAsync(...)
+{
+    await _consentSemaphore.WaitAsync(ct);
+    try
+    {
+        // Render prompt, collect response
+    }
+    finally
+    {
+        _consentSemaphore.Release();
+    }
+}
+```
+
+### Path Traversal in Glob (EC-007)
+
+Before expanding any glob pattern, validate it doesn't contain path traversal:
+```csharp
+if (pattern.Contains("..") || Path.IsPathRooted(pattern))
+    throw new ArgumentException($"Glob pattern must not contain path traversal: '{pattern}'");
+```
+
+## Implementer Autonomy
+
+This issue was authored from a specification and plan — the guidance above reflects our best understanding at issue-creation time, but **the implementer will have ground truth that we don't have yet**.
+
+**Standing directive:** If, during implementation, you discover that a different approach would better satisfy the Requirements above — a more elegant fix, a simpler design, a more robust solution — **you have full authority to deviate from the Implementation Guidance.** The Requirements section is the contract; the Implementation Guidance section is a starting point.
+
+When deviating:
+1. **Verify** the alternative still satisfies every item in Requirements.
+2. **Document** the deviation and your reasoning in the PR description.
+3. **Do not** silently drop requirements or weaken test coverage.
+
+## Testing Requirements
+
+### Test Approach
+
+- **Test level:** Integration (primarily) + Unit for isolated logic
+- **Test project:** `BitPantry.CommandLine.Tests.Remote.SignalR`
+- **Existing fixtures to reuse:** `TestEnvironment`, `VirtualConsole`, `MockFileSystem`, `TempFileScope`
+
+### Prescribed Test Cases
+
+| # | Test Name Pattern | Scenario | Expected Outcome |
+|---|-------------------|----------|------------------|
+| 1 | `GetFile_ClientDisconnects_ThrowsAndCleansUp` | Kill connection mid-transfer | Exception thrown, no temp file remains |
+| 2 | `SaveFile_ClientDisconnects_PartialFileRemoved` | Kill connection mid-download | Partial file deleted from client |
+| 3 | `GetFile_ExceedsMaxSize_ThrowsBeforeTransfer` | MaxFileSizeBytes=1KB, file is 10KB | InvalidOperationException, no upload started |
+| 4 | `GetFile_FileNotFound_ThrowsFileNotFoundException` | Request non-existent file | FileNotFoundException with original path |
+| 5 | `GetFile_PathTraversal_Rejected` | Pattern `../../etc/passwd` | ArgumentException |
+| 6 | `GetFile_ConcurrentCalls_PromptsNotInterleaved` | Two GetFileAsync calls, no --allow-path | Consent prompts appear sequentially |
+| 7 | `GetFile_Cancelled_ThrowsOperationCanceled` | Cancel token mid-stream | OperationCanceledException |
+| 8 | `ClientFile_Dispose_CleansUpTempFile` | Dispose a ClientFile | Temp file deleted |
+| 9 | `GetFile_EmptyFile_TransfersCorrectly` | 0-byte file | ClientFile with 0-length stream |
+| 10 | `SaveFile_EmptyFile_CreatesZeroByteFile` | Save 0-byte stream | File exists with 0 bytes |
+| 11 | `GetFiles_GlobWithPathTraversal_Rejected` | `../**/*.txt` | ArgumentException before expansion |
+| 12 | `ClientFile_NotDisposed_FinalizerDoesNotThrow` | Create ClientFile, don't dispose, let GC collect | No exception, optional log warning |
+
+### Discovering Additional Test Cases
+
+The test cases above are a starting point. During implementation, **discover and add additional test cases** as you encounter edge cases or error paths not covered above.
+
+### TDD Workflow
+
+Follow the `tdd-workflow` skill: write failing tests first (RED), implement (GREEN), refactor.

--- a/specs/012-client-file-access/issues/execution-plan.md
+++ b/specs/012-client-file-access/issues/execution-plan.md
@@ -1,0 +1,90 @@
+# Execution Plan: 012 — Client File Access
+
+**Spec**: `specs/012-client-file-access/spec.md`
+**Plan**: `specs/012-client-file-access/plan.md`
+**Date**: 2026-04-15
+
+## Dependency Graph
+
+```
+Level 1 (independent):  001  002  004
+                          \   |   /
+Level 2:                  003  005
+                            \  /
+Level 3:                    006
+                             |
+Level 4:                    007
+                             |
+Level 5:                    008
+```
+
+## Execution Levels
+
+### Level 1 — Core Types & Foundation (3 parallel tracks)
+
+| Issue | Title | Blocked By | Est. Complexity |
+|-------|-------|-----------|-----------------|
+| 001 | Core types: IClientFileAccess, ClientFile, local impl | — | Medium |
+| 002 | Protocol message envelopes | — | Low |
+| 004 | Consent policy and --allow-path | — | Medium |
+
+**Max parallelism**: 3 — all issues are independent.
+
+### Level 2 — Server & Client Implementations
+
+| Issue | Title | Blocked By | Est. Complexity |
+|-------|-------|-----------|-----------------|
+| 003 | RemoteClientFileAccess server impl | 001, 002 | High |
+| 005 | Client handler and consent UX | 002, 004 | High |
+
+**Max parallelism**: 2 — 003 and 005 are independent of each other.
+
+### Level 3 — Integration Round-Trip
+
+| Issue | Title | Blocked By | Est. Complexity |
+|-------|-------|-----------|-----------------|
+| 006 | End-to-end integration: single file | 003, 005 | High |
+
+**Max parallelism**: 1 — requires both server and client implementations.
+
+### Level 4 — Glob Pattern Support
+
+| Issue | Title | Blocked By | Est. Complexity |
+|-------|-------|-----------|------------------|
+| 007 | Glob pattern support: GetFilesAsync | 006 | High |
+
+### Level 5 — Hardening
+
+| Issue | Title | Blocked By | Est. Complexity |
+|-------|-------|-----------|------------------|
+| 008 | Edge cases and hardening | 006, 007 | Medium |
+
+## Critical Path
+
+```
+001 → 003 → 006 → 007 → 008
+```
+
+5 sequential steps across 5 levels. Issues 002 and 004 can execute in parallel with 001 but are not on the critical path.
+
+## Issue Summary
+
+| # | Title | Phase | Blocked By |
+|---|-------|-------|-----------|
+| 001 | Core types: IClientFileAccess, ClientFile, local impl | 1 | — |
+| 002 | Protocol message envelopes | 1 | — |
+| 003 | RemoteClientFileAccess server impl | 2 | 001, 002 |
+| 004 | Consent policy and --allow-path | 1 | — |
+| 005 | Client handler and consent UX | 2 | 002, 004 |
+| 006 | End-to-end integration: single file | 3 | 003, 005 |
+| 007 | Glob pattern support: GetFilesAsync | 4 | 006 |
+| 008 | Edge cases and hardening | 4 | 006, 007 |
+
+## Recommended Execution Order
+
+1. Start 001, 002, 004 in parallel
+2. When 001 + 002 complete → start 003
+3. When 002 + 004 complete → start 005
+4. When 003 + 005 complete → start 006
+5. When 006 completes → start 007
+6. When 007 completes → start 008

--- a/specs/012-client-file-access/plan.md
+++ b/specs/012-client-file-access/plan.md
@@ -1,0 +1,368 @@
+# Implementation Plan: Client File Access
+
+**Spec**: `012-client-file-access` | **Date**: 2026-04-15
+**Input**: `specs/012-client-file-access/spec.md`
+
+## Summary
+
+Add a location-transparent `IClientFileAccess` service that lets commands read/write files on the user's machine regardless of execution context. Two implementations: `LocalClientFileAccess` (direct file I/O for client-side execution) and `RemoteClientFileAccess` (coordinates SignalR push messages + existing HTTP file transfer for server-side execution). The client handles consent prompts, console output buffering, and actual HTTP transfers. The server implementation sends push messages via `HubInvocationContext` and awaits responses via `RpcMessageRegistry`. No new HTTP endpoints — all file transfer reuses existing `/fileupload` and `/filedownload`.
+
+## Technical Context
+
+**Runtime**: .NET 8.0 (VirtualConsole targets .NET Standard 2.0)
+**Framework**: ASP.NET Core SignalR (server), Spectre.Console (console UI)
+**Key Dependencies**:
+- Existing: `System.IO.Abstractions`, `Microsoft.Extensions.FileSystemGlobbing`, `Spectre.Console`, `Microsoft.AspNetCore.SignalR.Client`
+- New: None (all dependencies already in the solution)
+**Storage**: Server sandbox for temp file staging; client local file system for final storage
+**Testing**: MSTest 3.6.1 + FluentAssertions 6.12.0 + Moq + MockFileSystem + TestEnvironment (integration) + VirtualConsole (UX)
+**Constraints**:
+- `MaxFileSizeBytes` enforced for all transfers
+- Path traversal protection via `SandboxedFileSystem` on server staging
+- Client consent required for all server-initiated file access unless pre-allowed
+
+## Project Structure
+
+### New/Modified Files
+
+```text
+BitPantry.CommandLine/
+├── Client/
+│   ├── IClientFileAccess.cs                    ← NEW: interface
+│   ├── ClientFile.cs                           ← NEW: disposable file handle
+│   ├── FileTransferProgress.cs                 ← NEW: progress record
+│   ├── FileAccessDeniedException.cs            ← NEW: exception
+│   └── LocalClientFileAccess.cs                ← NEW: local implementation
+├── ServiceCollectionExtensions.cs              ← MODIFY: register LocalClientFileAccess as default
+
+BitPantry.CommandLine.Remote.SignalR/
+├── Envelopes/
+│   ├── PushMessage.cs                          ← MODIFY: add PushMessageType values
+│   ├── ClientFileUploadRequest.cs              ← NEW: push message envelope
+│   ├── ClientFileDownloadRequest.cs            ← NEW: push message envelope
+│   ├── ClientFileEnumerateRequest.cs           ← NEW: push message envelope
+│   ├── ClientFileAccessResponse.cs             ← NEW: response envelope
+│   └── ServerRequest.cs                        ← MODIFY: add ServerRequestType.ClientFileAccessResponse
+
+BitPantry.CommandLine.Remote.SignalR.Server/
+├── ClientFileAccess/
+│   └── RemoteClientFileAccess.cs               ← NEW: server implementation
+├── Configuration/
+│   └── IServiceCollectionExtensions.cs         ← MODIFY: register RemoteClientFileAccess as scoped IClientFileAccess
+├── CommandLineHub.cs                           ← MODIFY: route ClientFileAccessResponse to RpcMessageRegistry
+
+BitPantry.CommandLine.Remote.SignalR.Client/
+├── FileAccessConsentPolicy.cs                  ← NEW: allow-path matching
+├── FileAccessConsentHandler.cs                 ← NEW: consent prompt + output buffering
+├── SignalRServerProxy.cs                       ← MODIFY: handle new push message types in ReceiveMessage
+├── CommandLineApplicationBuilderExtensions.cs  ← MODIFY: register consent infrastructure
+├── Commands/Server/
+│   └── ConnectCommand.cs                       ← MODIFY: add --allow-path argument
+```
+
+### Test Files
+
+```text
+BitPantry.CommandLine.Tests/
+├── ClientFileAccess/
+│   ├── LocalClientFileAccessTests.cs           ← NEW: unit tests for local impl
+│   └── ClientFileTests.cs                      ← NEW: unit tests for ClientFile disposal
+
+BitPantry.CommandLine.Tests.Remote.SignalR/
+├── ClientFileAccess/
+│   ├── RemoteClientFileAccessTests.cs          ← NEW: unit tests (mocked hub context)
+│   ├── FileAccessConsentPolicyTests.cs         ← NEW: unit tests for allow-path matching
+│   ├── FileAccessConsentHandlerTests.cs        ← NEW: UX tests (VirtualConsole)
+│   └── ClientFileAccessIntegrationTests.cs     ← NEW: full integration (TestEnvironment)
+```
+
+### Documentation
+
+```text
+specs/012-client-file-access/
+├── spec.md
+├── plan.md              ← this file
+└── data-model.md        ← entity definitions and message schemas
+```
+
+## Data Model
+
+See [data-model.md](./data-model.md) for entity definitions, message envelopes, and existing entity relationships.
+
+## Technical Design
+
+### 1. Interface & Types (`BitPantry.CommandLine`)
+
+`IClientFileAccess`, `ClientFile`, `FileTransferProgress`, and `FileAccessDeniedException` live in the core project so commands can reference them without depending on SignalR. See data-model.md for full definitions.
+
+`LocalClientFileAccess` depends only on `IFileSystem` (already registered as singleton in `ServiceCollectionExtensions.AddFileSystem()`).
+
+### 2. Protocol: Server → Client File Access Requests
+
+Uses the existing `PushMessage` / `ReceiveMessage` channel (server→client push) with three new message types. The client responds via `ServerRequest` / `ReceiveRequest` channel using new `ServerRequestType.ClientFileAccessResponse`.
+
+**GetFile flow** (server reads file from client):
+```
+Server: RemoteClientFileAccess.GetFileAsync("c:\data\report.csv")
+  1. Generate correlationId, register in RpcMessageRegistry
+  2. Send PushMessage(ClientFileUploadRequest) via HubInvocationContext.ClientProxy
+  3. Await RpcMessageRegistry.WaitForCompletion<ClientFileAccessResponse>()
+
+Client: SignalRServerProxy.ReceiveMessage()
+  1. Receives ClientFileUploadRequest
+  2. FileAccessConsentHandler checks policy / prompts user
+  3. If approved: calls FileTransferService.UploadFile(clientPath, serverTempPath)
+  4. Sends ServerRequest(ClientFileAccessResponse) with success/error
+  5. If denied: sends response with FileAccessDenied error
+
+Server: 
+  4. RpcMessageRegistry completes → open temp file → return ClientFile
+  5. ClientFile.DisposeAsync() deletes temp file
+```
+
+**SaveFile flow** (server writes file to client):
+```
+Server: RemoteClientFileAccess.SaveFileAsync(stream, "c:\backups\export.json")
+  1. Write stream to staging temp file in sandbox
+  2. Generate correlationId, register in RpcMessageRegistry
+  3. Send PushMessage(ClientFileDownloadRequest) via HubInvocationContext.ClientProxy
+  4. Await RpcMessageRegistry.WaitForCompletion<ClientFileAccessResponse>()
+
+Client: SignalRServerProxy.ReceiveMessage()
+  1. Receives ClientFileDownloadRequest
+  2. FileAccessConsentHandler checks policy / prompts user
+  3. If approved: calls FileTransferService.DownloadFile(serverPath, clientPath)
+  4. Sends ServerRequest(ClientFileAccessResponse) with success/error
+
+Server:
+  5. RpcMessageRegistry completes → delete staging temp file → return
+```
+
+**SaveFile(sourcePath, ...) flow** — same as above but skips writing to temp; uses `sourcePath` directly for the download.
+
+**GetFiles flow** (server reads multiple files from client via glob):
+```
+Server: RemoteClientFileAccess.GetFilesAsync("**/*.csv")
+  1. Send PushMessage(ClientFileEnumerateRequest) with glob pattern
+  2. Await response with matched file list
+
+Client:
+  1. Expand glob locally via GlobPatternHelper + FileSystemGlobbing
+  2. Apply ? wildcard post-filter
+  3. FileAccessConsentHandler checks/prompts for the batch
+  4. Send response with file list (path + size per file)
+
+Server:
+  3. For each file in response, yield via IAsyncEnumerable:
+     - Send individual ClientFileUploadRequest per file
+     - Await upload → return ClientFile
+```
+
+### 3. Consent Handler (`BitPantry.CommandLine.Remote.SignalR.Client`)
+
+`FileAccessConsentPolicy` is a simple class storing `List<string>` of allowed glob patterns from `--allow-path`. Uses `GlobPatternHelper.ContainsGlobCharacters` and `Matcher` for pattern matching against requested paths.
+
+`FileAccessConsentHandler` manages the UX:
+
+1. Check `FileAccessConsentPolicy.IsAllowed(path)` — if allowed, return immediately
+2. Set `_consoleOutputPaused = true` on the proxy's console output handler
+3. Wait 50ms for in-flight output to arrive and be buffered
+4. Flush buffered output
+5. Render consent prompt using Spectre.Console `Panel` with `Color.Yellow` border:
+   ```
+   ┌─ File Access Request ────────────────────┐
+   │ Server requests: c:\data\report.csv      │
+   │ Allow? [y/N]                             │
+   └──────────────────────────────────────────┘
+   ```
+6. Read key via local `Console.ReadKey()` (NOT via SignalR — this is client-local input)
+7. Clear prompt lines (ANSI cursor-up + clear-line, using existing `AnsiCodes`)
+8. Set `_consoleOutputPaused = false`, flush buffered output
+9. Return allow/deny decision
+
+For batch consent (glob), tiered display based on match count:
+
+**Small batch (≤ 10 files)** — full file list:
+```
+┌─ File Access Request ────────────────────────┐
+│ Server requests 3 files matching **/*.csv:   │
+│   c:\data\a.csv (12 KB)                     │
+│   c:\data\b.csv (8 KB)                      │
+│   c:\data\c.csv (45 KB)                     │
+│ Allow all? [y/N]                             │
+└──────────────────────────────────────────────┘
+```
+
+**Medium batch (11–50 files)** — first 5, last 2, collapsed middle:
+```
+┌─ File Access Request ────────────────────────┐
+│ Server requests 27 files matching **/*.csv:  │
+│   c:\data\a.csv (12 KB)                     │
+│   c:\data\b.csv (8 KB)                      │
+│   c:\data\c.csv (45 KB)                     │
+│   c:\data\d.csv (3 KB)                      │
+│   c:\data\e.csv (91 KB)                     │
+│   ... and 20 more (total: 1.2 MB)           │
+│   c:\data\z.csv (6 KB)                      │
+│   c:\data\zz.csv (14 KB)                    │
+│ Allow all 27 files? [y/N]                    │
+└──────────────────────────────────────────────┘
+```
+
+**Large batch (> 50 files)** — summary only:
+```
+┌─ File Access Request ────────────────────────┐
+│ Server requests 347 files matching **/*.log  │
+│ Total size: 84.5 MB                          │
+│ Directory: c:\logs\                          │
+│ Allow all 347 files? [y/N]                   │
+└──────────────────────────────────────────────┘
+```
+
+Thresholds are defined as constants in `FileAccessConsentHandler` (see data-model.md).
+
+**Console output buffering**: The `ConsoleOut` handler in `SignalRServerProxy` checks a volatile `bool _consoleOutputPaused` flag. When paused, incoming output is appended to a `ConcurrentQueue<string>`. When unpaused, the queue is drained.
+
+### 4. ConnectCommand Extension
+
+Add `--allow-path` to `ConnectCommand`:
+
+```csharp
+[Argument(Name = "allow-path")]
+[Alias('a')]
+[Rest]  // collects multiple values
+[Description("Client paths the server may access without prompting (glob patterns)")]
+public string[] AllowPaths { get; set; }
+```
+
+After successful connection, store in `FileAccessConsentPolicy`:
+```csharp
+_consentPolicy.SetAllowedPatterns(AllowPaths ?? Array.Empty<string>());
+```
+
+### 5. DI Registration
+
+**Server** (`IServiceCollectionExtensions.cs`):
+```csharp
+services.AddScoped<IClientFileAccess, RemoteClientFileAccess>();
+```
+Scoped because it depends on `HubInvocationContext` (per-request ambient context).
+
+**Client** (`CommandLineApplicationBuilderExtensions.cs`):
+```csharp
+builder.Services.AddSingleton<FileAccessConsentPolicy>();
+builder.Services.AddSingleton<FileAccessConsentHandler>();
+```
+
+**Core** (`ServiceCollectionExtensions.cs` or `CommandLineApplicationBuilder`):
+```csharp
+services.AddSingleton<IClientFileAccess, LocalClientFileAccess>();
+```
+The client project overrides this only if needed — in practice, client-side commands use `LocalClientFileAccess` and server-side commands use `RemoteClientFileAccess` (registered in server DI scope).
+
+### 6. Hub Routing
+
+`CommandLineHub.ReceiveRequest()` gets a new case:
+```csharp
+case ServerRequestType.ClientFileAccessResponse:
+    _rpcMsgReg.SetResponse(req);
+    break;
+```
+
+This routes the client's file access completion response to the `RpcMessageRegistry`, unblocking the `RemoteClientFileAccess` call that's `await`ing it.
+
+## Testing Strategy
+
+### Unit Tests
+
+| User Story | Test Class | What's Tested | Fixtures/Helpers |
+|-----------|-----------|---------------|------------------|
+| US-003, US-005 | `LocalClientFileAccessTests` | GetFile reads local file, SaveFile writes local file, SaveFile creates parent dirs, GetFiles expands glob | `MockFileSystem` |
+| US-002 | `ClientFileTests` | Disposal closes stream, disposal calls cleanup action, double-dispose is safe | None (pure unit) |
+| US-004 | `FileAccessConsentPolicyTests` | Pattern matching: exact, glob *, glob **, ?, no patterns = not allowed, case handling | None (pure unit) |
+| US-001, US-002 | `RemoteClientFileAccessTests` | GetFile sends push + awaits response, SaveFile writes temp + sends push, errors propagate, MaxFileSizeBytes enforced, temp cleanup on failure | `Mock<HubInvocationContext>`, `Mock<RpcMessageRegistry>`, `MockFileSystem` |
+
+### UX Tests
+
+| User Story | Test Class | What's Tested | Fixtures/Helpers |
+|-----------|-----------|---------------|------------------|
+| US-004, US-005 | `FileAccessConsentHandlerTests` | Prompt renders with correct path, approve returns true, deny returns false, prompt visually distinct (Panel markup), buffered output flushes after prompt, batch prompt shows file list | `VirtualConsole`, `VirtualConsoleAssertions` |
+
+### Integration Tests (TestEnvironment — real client/server)
+
+| User Story | Test Name | What's Tested | Infrastructure |
+|-----------|-----------|---------------|----------------|
+| US-001 | `SaveFile_RemoteCommand_FileAppearsOnClient` | Register test command on server that saves file via `IClientFileAccess` → verify file exists on client temp dir | `TestEnvironment`, temp dirs, `--allow-path` |
+| US-002 | `GetFile_RemoteCommand_ReadsClientFile` | Place file in client temp → register test command that reads via `IClientFileAccess` → verify command received correct content | `TestEnvironment`, temp dirs, `--allow-path` |
+| US-003 | `SaveFile_LocalCommand_WritesDirectly` | Register command locally → run → verify file written without server | `CommandLineApplication` (no server) |
+| US-003 | `GetFile_LocalCommand_ReadsDirectly` | Place file → register command locally → run → verify read | `CommandLineApplication` (no server) |
+| US-004 | `GetFile_NoAllowPath_PromptsForConsent` | Don't set `--allow-path` → server requests file → verify prompt appears on `VirtualConsole` | `TestEnvironment`, `VirtualConsole`, keyboard input |
+| US-004 | `GetFile_AllowPathConfigured_NoPrompt` | Set `--allow-path` → server requests file in allowed path → verify no prompt, transfer succeeds | `TestEnvironment`, `--allow-path` |
+| US-004 | `GetFile_UserDenies_CommandReceivesError` | Server requests file → simulate 'N' keypress → verify command gets `FileAccessDeniedException` | `TestEnvironment`, `VirtualConsole`, keyboard input |
+| US-005 | `ConsentPrompt_DuringOutput_OutputBuffered` | Run command that streams output AND requests file → verify output pauses during prompt → resumes after | `TestEnvironment`, `VirtualConsole` |
+| US-006 | `SaveFile_Stream_ContentArrivesOnClient` | Register command that saves `MemoryStream` → verify content on client | `TestEnvironment`, `--allow-path` |
+| US-007 | `GetFiles_GlobPattern_AllMatchesReturned` | Place 3 matching + 1 non-matching file → run command with glob → verify correct files received | `TestEnvironment`, `--allow-path` |
+| US-007 | `GetFiles_LazyEnumeration_TransfersPerIteration` | Run command consuming only first 2 of 5 matches → verify only 2 HTTP uploads occurred | `TestEnvironment`, HTTP request counting |
+| Edge | `GetFile_ClientDisconnects_ServerGetsError` | Start file request → disconnect client → verify server command gets exception | `TestEnvironment`, forced disconnect |
+| Edge | `SaveFile_ExceedsMaxSize_Rejected` | Generate file larger than `MaxFileSizeBytes` → verify rejection error | `TestEnvironment` |
+| Edge | `GetFile_FileNotFound_ReturnsError` | Request non-existent client file → verify `FileNotFoundException` | `TestEnvironment`, `--allow-path` |
+
+**Test Commands**: Integration tests will register purpose-built test commands on the server (e.g., `TestSaveFileCommand`, `TestGetFileCommand`) that use `IClientFileAccess` and expose results via pipeline data or temp file markers. These test commands live in the test project, registered via `TestEnvironment` server options.
+
+**TDD Approach**: Follow the `tdd-workflow` skill — write failing tests first (RED), implement to pass (GREEN), refactor.
+
+## Implementation Phases
+
+### Phase 1: Core Types & Local Implementation
+- **Purpose**: Deliver `IClientFileAccess` interface, `ClientFile`, `FileTransferProgress`, `FileAccessDeniedException`, and `LocalClientFileAccess`. Commands can use the service locally.
+- **Dependencies**: None (foundational)
+- **Delivers**: US-003 (local execution path), FR-001 through FR-005, FR-008, FR-015, FR-019
+- **Tests**: `LocalClientFileAccessTests`, `ClientFileTests` (unit)
+- **Integration**: `SaveFile_LocalCommand_WritesDirectly`, `GetFile_LocalCommand_ReadsDirectly`
+
+### Phase 2: Protocol Messages & Server Implementation
+- **Purpose**: Add message envelopes, extend `PushMessageType` / `ServerRequestType`, implement `RemoteClientFileAccess`, register in server DI. Server-side commands can now call `IClientFileAccess` methods.
+- **Dependencies**: Phase 1 (interface must exist)
+- **Delivers**: FR-006, FR-007, FR-016, FR-017, FR-018, FR-025
+- **Tests**: `RemoteClientFileAccessTests` (unit with mocked hub context)
+- **Note**: Client handler not yet implemented — server sends push messages but client can't handle them yet. Unit tests mock the response side.
+
+### Phase 3: Client Handler & Consent Infrastructure
+- **Purpose**: Implement `FileAccessConsentPolicy`, `FileAccessConsentHandler`, and the `ReceiveMessage` handler extensions in `SignalRServerProxy`. Add `--allow-path` to `ConnectCommand`. Wire up client DI. This completes the round-trip.
+- **Dependencies**: Phase 2 (server must send push messages)
+- **Delivers**: FR-009 through FR-014, FR-020, US-004, US-005
+- **Tests**: `FileAccessConsentPolicyTests` (unit), `FileAccessConsentHandlerTests` (UX/VirtualConsole)
+- **Integration**: `SaveFile_RemoteCommand_FileAppearsOnClient`, `GetFile_RemoteCommand_ReadsClientFile`, all consent integration tests, `SaveFile_Stream_ContentArrivesOnClient`
+
+### Phase 4: Glob Pattern Support
+- **Purpose**: Implement `GetFilesAsync` with lazy `IAsyncEnumerable` transfer, client-side glob expansion, and batch consent.
+- **Dependencies**: Phase 3 (single-file round-trip must work)
+- **Delivers**: FR-021 through FR-024, US-007
+- **Tests**: `GetFiles_GlobPattern_AllMatchesReturned`, `GetFiles_LazyEnumeration_TransfersPerIteration` (integration)
+
+### Phase 5: Edge Cases & Hardening
+- **Purpose**: Handle disconnection, partial file cleanup, max file size enforcement, file-not-found propagation, concurrent prompt serialization.
+- **Dependencies**: Phase 3, Phase 4
+- **Parallel with**: Can partially overlap Phase 4
+- **Delivers**: FR-020, FR-025, all edge cases from spec
+- **Tests**: `GetFile_ClientDisconnects_ServerGetsError`, `SaveFile_ExceedsMaxSize_Rejected`, `GetFile_FileNotFound_ReturnsError` (integration)
+
+### Phase Dependency Graph
+
+```
+Phase 1 (Core Types + Local)
+    │
+    ▼
+Phase 2 (Protocol + Server Impl)
+    │
+    ▼
+Phase 3 (Client Handler + Consent)
+    │         │
+    ▼         ▼
+Phase 4    Phase 5
+(Glob)     (Hardening) ← can partially overlap Phase 4
+```
+
+## Complexity Tracking
+
+> No constitution violations. Feature reuses all existing HTTP transfer infrastructure, SignalR messaging patterns, and DI registration conventions. No new external dependencies introduced.

--- a/specs/012-client-file-access/spec.md
+++ b/specs/012-client-file-access/spec.md
@@ -1,0 +1,204 @@
+# Feature Specification: Client File Access
+
+**Spec**: `012-client-file-access`
+**Created**: 2026-04-15
+**Status**: Draft
+
+## Overview
+
+This feature introduces a location-transparent file access service (`IClientFileAccess`) that allows commands to read and write files on the calling user's machine, regardless of whether the command runs locally or on a remote server. When running locally, operations go directly to the file system. When running on the server, the service coordinates file transfers over the existing SignalR/HTTP infrastructure invisibly. This eliminates the current two-step workflow of manually uploading/downloading files when a remote command needs client-side data.
+
+## Clarifications
+
+### Session 2026-04-15
+
+- Q: When no `--allow-path` is configured, should the default be prompt-for-everything or allow-everything? → A: Prompt for everything. There is only `--allow-path`, no `--deny-path`. If no allowed paths are set, every server-initiated file access prompts the user.
+- Q: Where are allowed paths configured? → A: On the `server connect` command (e.g., `server connect -u http://... --allow-path c:\data\**`). Per-session only.
+- Q: For glob GetFiles, should all files transfer eagerly or lazily as enumerated? → A: Lazy. Returns `IAsyncEnumerable<ClientFile>`. Each file transfers when the caller iterates to it. Lower memory, more control for the command.
+- Q: For glob GetFiles, should consent be per-file or batched? → A: Batch consent. One prompt showing the matched file list, single approve/deny for the whole set.
+- Q: Does `MaxFileSizeBytes` apply to `IClientFileAccess` transfers? → A: Yes, same limits apply.
+- Q: Should overwriting existing client files trigger a separate consent prompt even if the path is allowed? → A: No. Overwrite silently if the path is allowed.
+
+## User Stories
+
+### US-001: Server Command Saves Output File to Client Machine
+
+**As a** user running a remote command that produces a file, **I want** the output file saved directly to a path on my local machine, **so that** I don't have to manually download it from the server sandbox afterward.
+
+**Why this priority**: This is the primary motivation for the feature — eliminating the upload-to-sandbox / download-from-sandbox ceremony for command-generated output files.
+
+**Independent Test**: Can be tested by running a remote command that writes a file via the service and verifying the file appears on the client with correct content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected client and a remote command that produces a data file, **When** the command saves the file via `IClientFileAccess` specifying a client destination path, **Then** the file appears on the client machine at the specified path with correct content.
+2. **Given** a connected client and a remote command, **When** the command saves a file and the client destination's parent directory does not exist, **Then** the parent directories are created automatically and the file is saved.
+3. **Given** a connected client, **When** the command saves a file via `IClientFileAccess` and the client destination already exists, **Then** the existing file is overwritten.
+4. **Given** a remote command saving a file, **When** the client disconnects mid-transfer, **Then** the command receives an error (exception) and partial files are cleaned up on the client.
+
+---
+
+### US-002: Server Command Reads Input File from Client Machine
+
+**As a** user running a remote command that needs an input file, **I want** the command to read a file from my local machine directly, **so that** I don't have to manually upload it to the server sandbox first.
+
+**Why this priority**: The complement to US-001 — many commands need to consume client-side files (e.g., restore operations, config imports).
+
+**Independent Test**: Can be tested by placing a file on the client, running a remote command that reads it via the service, and verifying the command received the correct content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected client and a file on the client machine, **When** a remote command reads the file via `IClientFileAccess`, **Then** the command receives a stream with the file's content and metadata (name, size).
+2. **Given** a connected client, **When** a remote command reads a file that does not exist on the client, **Then** the command receives a clear error (e.g., `FileNotFoundException`).
+3. **Given** a remote command reading a client file, **When** the command disposes the returned file handle, **Then** any temporary server-side copies are cleaned up automatically.
+4. **Given** a remote command, **When** it initiates a file read without awaiting and continues other work, **Then** the file transfer proceeds concurrently and the command can await the result later.
+
+---
+
+### US-003: Same Command Works Locally and Remotely
+
+**As a** command author, **I want** to write file access code once using `IClientFileAccess`, **so that** the same command works whether it runs locally or on a remote server without any code changes.
+
+**Why this priority**: Location transparency is a core design principle of the command framework — commands should not know where they run.
+
+**Independent Test**: Can be tested by running the same command locally and remotely, verifying identical observable behavior in both cases.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command that uses `IClientFileAccess` to save a file, **When** the command runs locally (no server connection), **Then** the file is written directly to the local file system.
+2. **Given** a command that uses `IClientFileAccess` to read a file, **When** the command runs locally, **Then** the file is read directly from the local file system.
+3. **Given** a command that uses `IClientFileAccess`, **When** the command runs on the server, **Then** the service transparently handles the network file transfer — the command code is identical.
+
+---
+
+### US-004: Client Consents to Server File Access
+
+**As a** user, **I want** to be asked for consent before the server reads or writes files on my machine, **so that** a compromised or malicious server cannot silently access my files.
+
+**Why this priority**: Security is critical — the server must not be able to exfiltrate or overwrite arbitrary client files without the user's knowledge.
+
+**Independent Test**: Can be tested by issuing a file access request from the server and verifying the client prompts the user and respects their answer.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected client with default settings, **When** the server requests access to a file path not in the allowed list, **Then** the client displays a consent prompt showing the actual file path and waits for the user to approve or deny.
+2. **Given** a consent prompt is displayed, **When** the user approves, **Then** the file transfer proceeds.
+3. **Given** a consent prompt is displayed, **When** the user denies, **Then** the server receives an access-denied error and no file data is transferred.
+4. **Given** a connected client with pre-configured allowed paths (e.g., `--allow-path c:\data\**` on the `server connect` command), **When** the server requests a file within an allowed path, **Then** no prompt is shown and the transfer proceeds automatically.
+5. **Given** a connected client with no allowed paths configured, **When** the server requests any file, **Then** a consent prompt is displayed.
+
+---
+
+### US-005: Consent Prompt Does Not Corrupt Console Output
+
+**As a** user running a remote command that produces console output, **I want** the consent prompt to display cleanly without corrupting the command's output, **so that** I can read both the prompt and the command output without confusion.
+
+**Why this priority**: If the prompt disrupts the output stream (renders on top of progress bars, interleaves with text), users won't trust or understand it.
+
+**Independent Test**: Can be tested by running a command that streams console output and concurrently triggers a file access request, verifying the prompt renders distinctly and output resumes cleanly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remote command is streaming console output, **When** a consent prompt needs to display, **Then** the console output is temporarily buffered (paused) so the prompt renders on a clean line.
+2. **Given** a consent prompt is displayed and the user answers, **When** the prompt is dismissed, **Then** any buffered console output resumes and renders in order without loss.
+3. **Given** a consent prompt is displayed, **Then** the prompt is visually distinct from server-generated output (e.g., bordered panel, distinct color) so the user can clearly distinguish it from command output.
+4. **Given** a consent prompt is displayed, **Then** the prompt text is generated client-side (not by the server), showing the actual requested path, so the server cannot misrepresent what file is being accessed.
+
+---
+
+### US-006: Stream-Based Save for In-Memory Data
+
+**As a** command author, **I want** to save a stream (not just a file on disk) to the client's file system, **so that** I can generate data in memory and send it to the client without first writing a temporary file.
+
+**Why this priority**: Many commands generate output in memory (serialized JSON, computed reports). Requiring a temp file intermediary is wasteful and error-prone.
+
+**Independent Test**: Can be tested by a command that generates a `MemoryStream` and saves it via the service, verifying the content arrives on the client.
+
+**Acceptance Scenarios**:
+
+1. **Given** a remote command with a `MemoryStream` of generated data, **When** the command calls save with the stream and a client destination, **Then** the data is transferred to the client and written to the specified path.
+2. **Given** a remote command saving a stream, **When** no progress callback is provided, **Then** the transfer completes silently without competing for console output.
+
+---
+
+### US-007: Read Multiple Client Files by Glob Pattern
+
+**As a** command author, **I want** to read multiple files from the client's file system using a glob pattern, **so that** I can process batches of files (e.g., import all CSVs from a directory) without the user listing each one individually.
+
+**Why this priority**: Glob patterns are already a first-class concept in the existing upload/download commands. Consistency matters, and batch operations are a common need.
+
+**Independent Test**: Can be tested by placing multiple files on the client matching a pattern, running a remote command that reads them via the service, and verifying all matching files are received.
+
+**Acceptance Scenarios**:
+
+1. **Given** a client directory with `a.csv`, `b.csv`, `c.txt`, **When** a remote command calls get-files with pattern `*.csv`, **Then** the command receives file handles for `a.csv` and `b.csv` only.
+2. **Given** a client directory with nested subdirectories, **When** a remote command calls get-files with pattern `**/*.log`, **Then** all `.log` files in all subdirectories are returned.
+3. **Given** a glob pattern that matches no files, **When** a remote command calls get-files, **Then** the command receives an empty result (not an error).
+4. **Given** a glob pattern with `?` wildcards (e.g., `file?.txt`), **When** a remote command calls get-files, **Then** only files matching the single-character wildcard are returned.
+
+## Functional Requirements
+
+| ID | Requirement | User Stories | Priority |
+|----|------------|-------------|----------|
+| FR-001 | System MUST provide an `IClientFileAccess` service injectable into commands via DI | US-003 | MUST |
+| FR-002 | `IClientFileAccess` MUST expose a method to open a client-side file for reading, returning a disposable handle with stream access, file name, and file size | US-002, US-003 | MUST |
+| FR-003 | `IClientFileAccess` MUST expose a method to save a `Stream` to a client-side path | US-001, US-003, US-006 | MUST |
+| FR-004 | `IClientFileAccess` MUST expose a method to save a local (server-side or client-side) file path to a client-side path | US-001, US-003 | MUST |
+| FR-005 | When running locally, `IClientFileAccess` MUST perform direct file system operations without network transfer | US-003 | MUST |
+| FR-006 | When running on the server, `IClientFileAccess` MUST coordinate file transfers over the existing SignalR/HTTP infrastructure | US-001, US-002, US-003 | MUST |
+| FR-007 | The disposable file handle returned by the read method MUST clean up server-side temporary files on disposal when running remotely | US-002 | MUST |
+| FR-008 | The save methods MUST create parent directories on the destination if they do not exist | US-001 | MUST |
+| FR-009 | The client MUST prompt the user for consent before allowing server-initiated file reads or writes to paths not in the allowed list | US-004 | MUST |
+| FR-010 | The consent prompt MUST be rendered client-side using the actual requested path — the server MUST NOT control the prompt text | US-004, US-005 | MUST |
+| FR-011 | The client MUST support pre-configured allowed path patterns (via `--allow-path` on the `server connect` command) that bypass the consent prompt. There is no deny-path — paths not in the allowed list are prompted | US-004 | MUST |
+| FR-012 | The client MUST buffer console output while a consent prompt is active and flush it after the prompt is dismissed | US-005 | MUST |
+| FR-013 | The consent prompt MUST be visually distinct from server-generated command output | US-005 | MUST |
+| FR-014 | When the user denies consent, the server-side operation MUST receive an access-denied error | US-004 | MUST |
+| FR-015 | File transfer operations MUST be cancellable via `CancellationToken` | US-001, US-002 | MUST |
+| FR-016 | The server-to-client file transfer (save) MUST reuse the existing HTTP download endpoint and streaming infrastructure | US-001 | MUST |
+| FR-017 | The client-to-server file transfer (get) MUST reuse the existing HTTP upload endpoint and streaming infrastructure | US-002 | MUST |
+| FR-018 | The read method MUST support fire-and-forget usage (non-blocking initiation with later await) | US-002 | MUST |
+| FR-019 | All transfer methods MUST accept an optional progress callback parameter. The service MUST NOT render progress UI itself — progress display is the caller's responsibility | US-001, US-002, US-006 | MUST |
+| FR-020 | Partial files on the client SHOULD be cleaned up on transfer failure | US-001 | SHOULD |
+| FR-021 | `IClientFileAccess` MUST expose a method to read multiple client-side files matching a glob pattern, returning an `IAsyncEnumerable<ClientFile>` that transfers each file lazily as the caller iterates | US-007 | MUST |
+| FR-022 | Glob pattern expansion MUST reuse the existing `GlobPatternHelper` infrastructure including `?` wildcard post-filtering | US-007 | MUST |
+| FR-023 | When running on the server, glob expansion MUST happen client-side (where the files are) and results transferred individually | US-007 | MUST |
+| FR-024 | When running locally, glob expansion MUST use `Microsoft.Extensions.FileSystemGlobbing` on the local file system (consistent with existing upload command) | US-007 | MUST |
+| FR-025 | File transfers via `IClientFileAccess` MUST respect the server's `MaxFileSizeBytes` limit. Files exceeding the limit MUST be rejected with a clear error | US-001, US-002, US-007 | MUST |
+
+## Edge Cases
+
+- **Server requests file outside allowed paths and user denies** — The command receives an access-denied exception. The command is responsible for handling this gracefully (e.g., logging or reporting to the user). (Relates to: US-004, FR-014)
+- **Multiple concurrent file access requests from one command** — Each request generates its own consent prompt (if needed). Prompts are serialized on the client — only one displays at a time. (Relates to: US-005, FR-012)
+- **Client disconnects during file transfer** — The awaiting server-side task receives a cancellation/connection-lost exception. Temporary files on both sides are cleaned up. (Relates to: US-001, US-002, FR-015)
+- **Returned file handle not disposed** — Temporary server-side files leak. This is a caller bug, consistent with standard .NET `IAsyncDisposable` expectations. Finalizer/logging MAY warn but MUST NOT crash. (Relates to: US-002, FR-007)
+- **Save to a path that is read-only on the client** — The client file system throws an `IOException` or `UnauthorizedAccessException`. The error propagates back to the server command. (Relates to: US-001)
+- **File requested by server does not exist on client** — Client returns a file-not-found error via the protocol. The server command receives a `FileNotFoundException`. (Relates to: US-002)
+- **Very large file transfer** — Transfer uses streaming; file is not loaded into memory all at once. Consistent with existing upload/download behavior. (Relates to: US-001, US-002, FR-016, FR-017)
+- **Command runs locally and path does not exist** — Standard `FileNotFoundException` from the local file system. No special handling needed. (Relates to: US-003, FR-005)
+- **Consent prompt timeout** — If the user does not respond within a reasonable period, the system SHOULD NOT auto-approve. The transfer remains pending until the user acts or the command's cancellation token fires. (Relates to: US-004)
+- **Glob pattern matches many files requiring consent** — Consent prompt SHOULD batch-display the matched file list and request a single approve/deny for the group, rather than prompting per-file. (Relates to: US-004, US-007)
+- **Glob pattern expansion returns very large result set** — The service returns all matches lazily via `IAsyncEnumerable`. The command controls concurrency and memory by consuming items at its own pace. (Relates to: US-007)
+- **File exceeds MaxFileSizeBytes** — Transfer is rejected with a clear error. The command receives an exception indicating the file exceeds the size limit. (Relates to: FR-025)
+
+## Key Entities
+
+- **IClientFileAccess**: A service representing access to the calling user's file system. Abstracts the difference between local and remote execution. Commands inject this to read or write user-side files.
+- **ClientFile**: A disposable handle returned when reading a file. Provides stream access and metadata. On disposal, cleans up any temporary resources (e.g., server-side temp copies in the remote case).
+- **File Access Consent**: The client-side decision gate that evaluates each server-initiated file access request against configured allow/deny path patterns and optionally prompts the user. Controls whether a transfer proceeds.
+
+## Assumptions
+
+- The existing HTTP upload/download endpoints and `FileTransferService` are stable and sufficient for the file transfer payloads this feature generates. No changes to the HTTP transfer layer are assumed.
+- Commands that use `IClientFileAccess` accept that file transfers may take significant time and should use `CancellationToken` appropriately.
+- The consent mechanism applies only to server-initiated file access. The existing `server upload` and `server download` commands are explicitly user-initiated and do not require consent prompts.
+- Path allow configuration is per-session (configured at `server connect` time), not persisted across sessions by this feature.
+- The `--location` argument pattern (and similar client-side path arguments) will use the existing client-side file system autocomplete handler for tab completion.
+
+## Out of Scope
+
+- **Modification of existing `server upload` / `server download` commands** — Those remain as explicit user-initiated transfers. This feature adds a programmatic service for command authors.
+- **Directory transfer as a unit** — The glob method returns individual files, not directory trees. Preserving directory structure on the receiving end is the command's responsibility.
+- **Persistent consent rules** — Allow path configuration is session-scoped. Persisting rules to disk or a config file is a future enhancement.
+- **Bi-directional streaming** — The service is request/response per file. Continuous streaming (e.g., tailing a remote log to a local file) is not included.
+- **Save with glob destination** — Glob patterns apply only to the read/get direction (selecting source files). Save always targets a specific path.


### PR DESCRIPTION
## Spec 012: Client File Access

Adds the complete specification for a location-transparent `IClientFileAccess` service that lets commands read/write files on the user's machine regardless of execution context.

### Contents

- **spec.md** — 7 user stories, 25 functional requirements, 12 edge cases
- **plan.md** — 5-phase implementation plan with testing strategy
- **data-model.md** — Entity definitions, message schemas, constants
- **8 staged issues** (001–008) → GitHub #51–#58
- **execution-plan.md** — 5-level dependency graph with critical path

### Issue Map

| # | GitHub | Title |
|---|--------|-------|
| 001 | #51 | Core types: IClientFileAccess, ClientFile, local impl |
| 002 | #52 | Protocol message envelopes |
| 003 | #53 | RemoteClientFileAccess server impl |
| 004 | #54 | Consent policy and --allow-path |
| 005 | #55 | Client handler and consent UX |
| 006 | #56 | End-to-end integration |
| 007 | #57 | Glob pattern support |
| 008 | #58 | Edge cases and hardening |

Spec-only PR — no code changes.