### PR TITLE
Issue #57: Glob pattern support - GetFilesAsync with lazy enumeration

### DIFF
--- a/BitPantry.CommandLine.Remote.SignalR.Server/ClientFileAccess/RemoteClientFileAccess.cs
+++ b/BitPantry.CommandLine.Remote.SignalR.Server/ClientFileAccess/RemoteClientFileAccess.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using System.Runtime.CompilerServices;
 using BitPantry.CommandLine.Client;
 using BitPantry.CommandLine.Remote.SignalR.Envelopes;
 using BitPantry.CommandLine.Remote.SignalR.Server.Files;
@@ -89,6 +90,40 @@ namespace BitPantry.CommandLine.Remote.SignalR.Server.ClientFileAccess
             {
                 CleanupTempFile(tempPath);
                 throw;
+            }
+        }
+
+        public async IAsyncEnumerable<ClientFile> GetFilesAsync(
+            string clientGlobPattern,
+            IProgress<FileTransferProgress> progress = null,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var ctx = _hubInvocationContext.Current
+                ?? throw new InvalidOperationException("No hub invocation context available — cannot access client files outside of a hub invocation.");
+
+            // Send enumerate request to client
+            var enumerateRpcCtx = ctx.RpcMessageRegistry.Register();
+
+            var enumerateMsg = new ClientFileEnumerateRequestMessage(clientGlobPattern);
+            enumerateMsg.CorrelationId = enumerateRpcCtx.CorrelationId;
+
+            _logger.LogDebug("Requesting client file enumeration: {GlobPattern}, correlationId={CorrelationId}",
+                clientGlobPattern, enumerateRpcCtx.CorrelationId);
+
+            await ctx.ClientProxy.SendAsync(SignalRMethodNames.ReceiveMessage, enumerateMsg, ct);
+
+            var enumerateResponse = await enumerateRpcCtx.WaitForCompletion<ClientFileAccessResponseMessage>().WaitAsync(ct);
+
+            if (!enumerateResponse.Success)
+                throw MapError(enumerateResponse.Error, clientGlobPattern);
+
+            var fileEntries = enumerateResponse.FileInfoEntries;
+
+            // Yield individual files lazily — each triggers a separate upload request
+            foreach (var entry in fileEntries)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return await GetFileAsync(entry.Path, progress, ct);
             }
         }
 

--- a/BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/ClientFileAccessIntegrationTests.cs
+++ b/BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/ClientFileAccessIntegrationTests.cs
@@ -536,6 +536,219 @@ namespace BitPantry.CommandLine.Tests.Remote.SignalR.ClientFileAccess
 
         #endregion
 
+        #region Test 12: GetFiles_GlobPattern_AllMatchesReturned
+
+        /// <summary>
+        /// Server command calls GetFilesAsync with a glob pattern. Files matching the pattern
+        /// are returned; non-matching files are excluded.
+        ///
+        /// Test Validity Check:
+        ///   Invokes code under test: YES - exercises full GetFilesAsync round-trip with glob
+        ///   Breakage detection: YES - count and filename assertions fail if glob expansion broken
+        ///   Not a tautology: YES
+        ///
+        /// Implements: FR-021, FR-022, FR-023
+        /// </summary>
+        [TestMethod]
+        [Timeout(15000)]
+        [Ignore("Blocked by #67: RpcMessageRegistry is scoped per hub invocation — ClientFileAccessResponse arriving in a separate ReceiveRequest invocation cannot find the RpcMessageContext registered during Run. Fix: singleton ClientFileAccessRpcBridge.")]
+        public async Task GetFiles_GlobPattern_AllMatchesReturned()
+        {
+            // Arrange
+            using var clientTemp = new TempDirectoryScope(createDirectory: true);
+            File.WriteAllText(Path.Combine(clientTemp.Path, "report.csv"), "csv1");
+            File.WriteAllText(Path.Combine(clientTemp.Path, "summary.csv"), "csv2");
+            File.WriteAllText(Path.Combine(clientTemp.Path, "data.csv"), "csv3");
+            File.WriteAllText(Path.Combine(clientTemp.Path, "readme.txt"), "not-a-csv");
+
+            using var env = new TestEnvironment(opt => opt.ConfigureServer(svr =>
+            {
+                svr.ConfigureCommands(cmd =>
+                {
+                    cmd.RegisterCommand<TestGetFilesCommand>();
+                });
+            }));
+
+            await env.ConnectToServerAsync(allowPaths: new[] { clientTemp.Path + "/**" });
+
+            // Act
+            var pattern = Path.Combine(clientTemp.Path, "*.csv").Replace("\\", "/");
+            var result = await env.RunCommandAsync($"test-get-files {pattern}", timeoutMs: 10000);
+
+            // Assert
+            result.ResultCode.Should().Be(0, BuildErrorInfo(env, result));
+            env.Console.VirtualConsole.Should().ContainText("GetFiles:total=3");
+            env.Console.VirtualConsole.Should().ContainText("GetFiles:report.csv:csv1");
+            env.Console.VirtualConsole.Should().ContainText("GetFiles:summary.csv:csv2");
+            env.Console.VirtualConsole.Should().ContainText("GetFiles:data.csv:csv3");
+            env.Console.VirtualConsole.Should().NotContainText("readme.txt");
+        }
+
+        #endregion
+
+        #region Test 13: GetFiles_LazyEnumeration_TransfersPerIteration
+
+        /// <summary>
+        /// Server command iterates only first 2 of 5 matching files via --limit.
+        /// Only 2 files should be transferred.
+        ///
+        /// Test Validity Check:
+        ///   Invokes code under test: YES - exercises lazy enumeration with partial iteration
+        ///   Breakage detection: YES - total count assertion fails if all 5 transferred
+        ///   Not a tautology: YES
+        ///
+        /// Implements: FR-021 (lazy enumeration)
+        /// </summary>
+        [TestMethod]
+        [Timeout(15000)]
+        [Ignore("Blocked by #67: RpcMessageRegistry is scoped per hub invocation — ClientFileAccessResponse arriving in a separate ReceiveRequest invocation cannot find the RpcMessageContext registered during Run. Fix: singleton ClientFileAccessRpcBridge.")]
+        public async Task GetFiles_LazyEnumeration_TransfersPerIteration()
+        {
+            // Arrange
+            using var clientTemp = new TempDirectoryScope(createDirectory: true);
+            for (int i = 1; i <= 5; i++)
+                File.WriteAllText(Path.Combine(clientTemp.Path, $"file{i}.csv"), $"content{i}");
+
+            using var env = new TestEnvironment(opt => opt.ConfigureServer(svr =>
+            {
+                svr.ConfigureCommands(cmd =>
+                {
+                    cmd.RegisterCommand<TestGetFilesCommand>();
+                });
+            }));
+
+            await env.ConnectToServerAsync(allowPaths: new[] { clientTemp.Path + "/**" });
+
+            // Act — only consume first 2 of 5
+            var pattern = Path.Combine(clientTemp.Path, "*.csv").Replace("\\", "/");
+            var result = await env.RunCommandAsync($"test-get-files {pattern} --limit 2", timeoutMs: 10000);
+
+            // Assert
+            result.ResultCode.Should().Be(0, BuildErrorInfo(env, result));
+            env.Console.VirtualConsole.Should().ContainText("GetFiles:total=2");
+        }
+
+        #endregion
+
+        #region Test 14: GetFiles_BatchConsent_ShowsFileList
+
+        /// <summary>
+        /// When no --allow-path is configured and ≤10 files match, the consent panel
+        /// shows all file paths (small batch tier).
+        ///
+        /// Test Validity Check:
+        ///   Invokes code under test: YES - exercises batch consent prompt with file list
+        ///   Breakage detection: YES - console content assertion fails if tiered display broken
+        ///   Not a tautology: YES
+        ///
+        /// Implements: spec batch consent tiered display
+        /// </summary>
+        [TestMethod]
+        [Timeout(15000)]
+        [Ignore("Blocked by #67: RpcMessageRegistry is scoped per hub invocation — ClientFileAccessResponse arriving in a separate ReceiveRequest invocation cannot find the RpcMessageContext registered during Run. Fix: singleton ClientFileAccessRpcBridge.")]
+        public async Task GetFiles_BatchConsent_ShowsFileList()
+        {
+            // Arrange
+            using var clientTemp = new TempDirectoryScope(createDirectory: true);
+            File.WriteAllText(Path.Combine(clientTemp.Path, "a.csv"), "aa");
+            File.WriteAllText(Path.Combine(clientTemp.Path, "b.csv"), "bb");
+            File.WriteAllText(Path.Combine(clientTemp.Path, "c.csv"), "cc");
+
+            using var env = new TestEnvironment(opt => opt.ConfigureServer(svr =>
+            {
+                svr.ConfigureCommands(cmd =>
+                {
+                    cmd.RegisterCommand<TestGetFilesCommand>();
+                });
+            }));
+
+            // Connect WITHOUT --allow-path
+            await env.ConnectToServerAsync();
+
+            // Act - start command (it will block on batch consent prompt)
+            var pattern = Path.Combine(clientTemp.Path, "*.csv").Replace("\\", "/");
+            await env.Keyboard.SubmitAsync($"test-get-files {pattern}");
+
+            // Wait for batch consent prompt to appear
+            await WaitForConsoleText(env, "File Access Request", timeoutMs: 8000);
+
+            // Verify prompt shows file paths (small batch: all files listed)
+            env.Console.VirtualConsole.Should().ContainText("a.csv");
+            env.Console.VirtualConsole.Should().ContainText("b.csv");
+            env.Console.VirtualConsole.Should().ContainText("c.csv");
+
+            // Approve consent
+            env.Input.PushKey(ConsoleKey.Y);
+
+            // Wait for command to complete
+            await env.WaitForInputReadyAsync(timeoutMs: 8000);
+
+            // Assert - command completed with the file content
+            env.Console.VirtualConsole.Should().ContainText("GetFiles:total=3");
+        }
+
+        #endregion
+
+        #region Test 15: GetFiles_BatchConsent_LargeSet_ShowsSummary
+
+        /// <summary>
+        /// When >50 files match, the consent panel shows summary only
+        /// (count + total size), not individual filenames.
+        ///
+        /// Test Validity Check:
+        ///   Invokes code under test: YES - exercises large batch consent summary display
+        ///   Breakage detection: YES - console assertions fail if tiered display broken
+        ///   Not a tautology: YES
+        ///
+        /// Implements: spec batch consent tiered display (>50 files)
+        /// </summary>
+        [TestMethod]
+        [Timeout(30000)]
+        [Ignore("Blocked by #67: RpcMessageRegistry is scoped per hub invocation — ClientFileAccessResponse arriving in a separate ReceiveRequest invocation cannot find the RpcMessageContext registered during Run. Fix: singleton ClientFileAccessRpcBridge.")]
+        public async Task GetFiles_BatchConsent_LargeSet_ShowsSummary()
+        {
+            // Arrange — create >50 files
+            using var clientTemp = new TempDirectoryScope(createDirectory: true);
+            for (int i = 1; i <= 55; i++)
+                File.WriteAllText(Path.Combine(clientTemp.Path, $"file{i:D3}.csv"), $"data{i}");
+
+            using var env = new TestEnvironment(opt => opt.ConfigureServer(svr =>
+            {
+                svr.ConfigureCommands(cmd =>
+                {
+                    cmd.RegisterCommand<TestGetFilesCommand>();
+                });
+            }));
+
+            // Connect WITHOUT --allow-path
+            await env.ConnectToServerAsync();
+
+            // Act - start command (it will block on batch consent prompt)
+            var pattern = Path.Combine(clientTemp.Path, "*.csv").Replace("\\", "/");
+            await env.Keyboard.SubmitAsync($"test-get-files {pattern}");
+
+            // Wait for batch consent prompt
+            await WaitForConsoleText(env, "File Access Request", timeoutMs: 8000);
+
+            // Verify prompt shows summary (not all filenames) — large batch tier
+            env.Console.VirtualConsole.Should().ContainText("55 files");
+            env.Console.VirtualConsole.Should().ContainText("Total size:");
+
+            // Should NOT show all individual filenames (>50 = summary only)
+            env.Console.VirtualConsole.Should().NotContainText("file001.csv",
+                "large batch should show summary, not individual files");
+
+            // Approve consent
+            env.Input.PushKey(ConsoleKey.Y);
+
+            // Wait for command to complete
+            await env.WaitForInputReadyAsync(timeoutMs: 20000);
+
+            env.Console.VirtualConsole.Should().ContainText("GetFiles:total=55");
+        }
+
+        #endregion
+
         #region Helper Methods
 
         /// <summary>

--- a/BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/TestCommands/TestGetFilesCommand.cs
+++ b/BitPantry.CommandLine.Tests.Remote.SignalR/ClientFileAccess/TestCommands/TestGetFilesCommand.cs
@@ -1,0 +1,46 @@
+using BitPantry.CommandLine.API;
+using BitPantry.CommandLine.Client;
+using Spectre.Console;
+
+namespace BitPantry.CommandLine.Tests.Remote.SignalR.ClientFileAccess.TestCommands
+{
+    /// <summary>
+    /// Test command that reads multiple files from the client via IClientFileAccess.GetFilesAsync.
+    /// Writes each file name and content to the server console to prove the round-trip.
+    /// Supports --limit to test lazy enumeration (partial iteration).
+    /// </summary>
+    [Command(Name = "test-get-files")]
+    public class TestGetFilesCommand : CommandBase
+    {
+        [Argument(Position = 0)]
+        public string GlobPattern { get; set; }
+
+        [Argument(Name = "--limit")]
+        public int Limit { get; set; } = 0;
+
+        private readonly IClientFileAccess _clientFiles;
+
+        public TestGetFilesCommand(IClientFileAccess clientFiles)
+        {
+            _clientFiles = clientFiles;
+        }
+
+        public async Task Execute(CommandExecutionContext ctx)
+        {
+            int count = 0;
+            await foreach (var file in _clientFiles.GetFilesAsync(GlobPattern, ct: ctx.CancellationToken))
+            {
+                await using (file)
+                {
+                    using var reader = new StreamReader(file.Stream);
+                    var content = await reader.ReadToEndAsync(ctx.CancellationToken);
+                    Console.WriteLine($"GetFiles:{file.FileName}:{content}");
+                }
+                count++;
+                if (Limit > 0 && count >= Limit)
+                    break;
+            }
+            Console.WriteLine($"GetFiles:total={count}");
+        }
+    }
+}

--- a/BitPantry.CommandLine.Tests.Remote.SignalR/ServerTests/RemoteClientFileAccessTests.cs
+++ b/BitPantry.CommandLine.Tests.Remote.SignalR/ServerTests/RemoteClientFileAccessTests.cs
@@ -522,6 +522,206 @@ public class RemoteClientFileAccessTests
     }
 
     // ──────────────────────────────────────────────────────
+    // GetFilesAsync tests
+    // ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task GetFilesAsync_SendsEnumerateRequest_WithGlobPattern()
+    {
+        // Test Validity Check:
+        //   Invokes code under test: YES - calls GetFilesAsync
+        //   Breakage detection: YES - verifies enumerate push message sent with correct pattern
+        //   Not a tautology: YES
+
+        ClientFileEnumerateRequestMessage capturedEnumMsg = null;
+
+        var proxy = new PushMessageAutoRespondingClientProxy(_rpcMsgReg, (correlationId, msg) =>
+        {
+            if (msg is ClientFileEnumerateRequestMessage enumMsg)
+            {
+                capturedEnumMsg = enumMsg;
+                // Return empty file list — no files to iterate
+                return new ClientFileAccessResponseMessage(true, fileInfoEntries: Array.Empty<FileInfoEntry>());
+            }
+
+            // Handle upload requests
+            if (msg is ClientFileUploadRequestMessage uploadReq)
+            {
+                _fileSystem.AddFile(uploadReq.ServerTempPath, new MockFileData("content"));
+                return new ClientFileAccessResponseMessage(true);
+            }
+
+            return new ClientFileAccessResponseMessage(true);
+        });
+
+        SetupContext(proxy);
+        var sut = CreateSut();
+
+        await foreach (var _ in sut.GetFilesAsync("**/*.csv"))
+        {
+            // Just iterate
+        }
+
+        capturedEnumMsg.Should().NotBeNull();
+        capturedEnumMsg!.GlobPattern.Should().Be("**/*.csv");
+    }
+
+    [TestMethod]
+    public async Task GetFilesAsync_WithMatchingFiles_YieldsClientFilesLazily()
+    {
+        // Test Validity Check:
+        //   Invokes code under test: YES - calls GetFilesAsync and iterates
+        //   Breakage detection: YES - verifies correct number of files returned, each with upload request
+        //   Not a tautology: YES
+
+        var uploadRequestCount = 0;
+
+        var proxy = new PushMessageAutoRespondingClientProxy(_rpcMsgReg, (correlationId, msg) =>
+        {
+            if (msg is ClientFileEnumerateRequestMessage)
+            {
+                // Return 3 matching files
+                return new ClientFileAccessResponseMessage(true, fileInfoEntries: new[]
+                {
+                    new FileInfoEntry("/client/a.csv", 100, DateTime.UtcNow),
+                    new FileInfoEntry("/client/b.csv", 200, DateTime.UtcNow),
+                    new FileInfoEntry("/client/c.csv", 300, DateTime.UtcNow)
+                });
+            }
+
+            if (msg is ClientFileUploadRequestMessage uploadReq)
+            {
+                Interlocked.Increment(ref uploadRequestCount);
+                _fileSystem.AddFile(uploadReq.ServerTempPath, new MockFileData($"content-{uploadReq.ClientPath}"));
+                return new ClientFileAccessResponseMessage(true);
+            }
+
+            return new ClientFileAccessResponseMessage(true);
+        });
+
+        SetupContext(proxy);
+        var sut = CreateSut();
+
+        var results = new List<ClientFile>();
+        await foreach (var file in sut.GetFilesAsync("**/*.csv"))
+        {
+            results.Add(file);
+        }
+
+        results.Should().HaveCount(3);
+        uploadRequestCount.Should().Be(3, "each file should trigger an individual upload request");
+
+        foreach (var file in results)
+            await file.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task GetFilesAsync_ClientDenies_ThrowsFileAccessDeniedException()
+    {
+        // Test Validity Check:
+        //   Invokes code under test: YES - calls GetFilesAsync
+        //   Breakage detection: YES - verifies exception on denied response
+        //   Not a tautology: YES
+
+        var proxy = new PushMessageAutoRespondingClientProxy(_rpcMsgReg, (correlationId, msg) =>
+        {
+            return new ClientFileAccessResponseMessage(false, "FileAccessDenied");
+        });
+
+        SetupContext(proxy);
+        var sut = CreateSut();
+
+        Func<Task> act = async () =>
+        {
+            await foreach (var _ in sut.GetFilesAsync("**/*.csv"))
+            {
+                // iteration should throw before yielding
+            }
+        };
+
+        await act.Should().ThrowAsync<FileAccessDeniedException>();
+    }
+
+    [TestMethod]
+    public async Task GetFilesAsync_EmptyResponse_ReturnsNoFiles()
+    {
+        // Test Validity Check:
+        //   Invokes code under test: YES - calls GetFilesAsync
+        //   Breakage detection: YES - verifies empty enumerable on empty response
+        //   Not a tautology: YES
+
+        var proxy = new PushMessageAutoRespondingClientProxy(_rpcMsgReg, (correlationId, msg) =>
+        {
+            return new ClientFileAccessResponseMessage(true, fileInfoEntries: Array.Empty<FileInfoEntry>());
+        });
+
+        SetupContext(proxy);
+        var sut = CreateSut();
+
+        var results = new List<ClientFile>();
+        await foreach (var file in sut.GetFilesAsync("**/*.csv"))
+        {
+            results.Add(file);
+        }
+
+        results.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task GetFilesAsync_LazyTransfer_OnlyUploadsIteratedFiles()
+    {
+        // Test Validity Check:
+        //   Invokes code under test: YES - calls GetFilesAsync with partial iteration
+        //   Breakage detection: YES - verifies only 2 of 5 uploads triggered
+        //   Not a tautology: YES
+
+        var uploadRequestCount = 0;
+
+        var proxy = new PushMessageAutoRespondingClientProxy(_rpcMsgReg, (correlationId, msg) =>
+        {
+            if (msg is ClientFileEnumerateRequestMessage)
+            {
+                return new ClientFileAccessResponseMessage(true, fileInfoEntries: new[]
+                {
+                    new FileInfoEntry("/client/f1.csv", 100, DateTime.UtcNow),
+                    new FileInfoEntry("/client/f2.csv", 200, DateTime.UtcNow),
+                    new FileInfoEntry("/client/f3.csv", 300, DateTime.UtcNow),
+                    new FileInfoEntry("/client/f4.csv", 400, DateTime.UtcNow),
+                    new FileInfoEntry("/client/f5.csv", 500, DateTime.UtcNow)
+                });
+            }
+
+            if (msg is ClientFileUploadRequestMessage uploadReq)
+            {
+                Interlocked.Increment(ref uploadRequestCount);
+                _fileSystem.AddFile(uploadReq.ServerTempPath, new MockFileData("content"));
+                return new ClientFileAccessResponseMessage(true);
+            }
+
+            return new ClientFileAccessResponseMessage(true);
+        });
+
+        SetupContext(proxy);
+        var sut = CreateSut();
+
+        var results = new List<ClientFile>();
+        int count = 0;
+        await foreach (var file in sut.GetFilesAsync("**/*.csv"))
+        {
+            results.Add(file);
+            count++;
+            if (count >= 2)
+                break;
+        }
+
+        results.Should().HaveCount(2);
+        uploadRequestCount.Should().Be(2, "only 2 of 5 files should have been uploaded");
+
+        foreach (var file in results)
+            await file.DisposeAsync();
+    }
+
+    // ──────────────────────────────────────────────────────
     // Test helpers
     // ──────────────────────────────────────────────────────
 

--- a/BitPantry.CommandLine.Tests/Client/LocalClientFileAccessTests.cs
+++ b/BitPantry.CommandLine.Tests/Client/LocalClientFileAccessTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -256,6 +257,189 @@ namespace BitPantry.CommandLine.Tests.Client
 
             // Assert
             await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        // ── GetFilesAsync ────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task GetFilesAsync_StarGlob_ReturnsMatchingFiles()
+        {
+            // Test Validity Check:
+            //   Invokes code under test: YES (GetFilesAsync)
+            //   Breakage detection: YES (verifies correct file count and names)
+            //   Not a tautology: YES (glob expansion + file opening)
+
+            // Arrange
+            _fs.AddFile("/data/report.csv", new MockFileData("csv1"));
+            _fs.AddFile("/data/summary.csv", new MockFileData("csv2"));
+            _fs.AddFile("/data/readme.txt", new MockFileData("text"));
+
+            // Act
+            var results = new List<ClientFile>();
+            await foreach (var file in _sut.GetFilesAsync("/data/*.csv"))
+            {
+                results.Add(file);
+            }
+
+            // Assert
+            results.Should().HaveCount(2);
+            results.Select(f => f.FileName).Should().BeEquivalentTo("report.csv", "summary.csv");
+
+            foreach (var file in results)
+                await file.DisposeAsync();
+        }
+
+        [TestMethod]
+        public async Task GetFilesAsync_DoubleStarGlob_MatchesRecursive()
+        {
+            // Test Validity Check:
+            //   Invokes code under test: YES (GetFilesAsync)
+            //   Breakage detection: YES (verifies recursive match)
+            //   Not a tautology: YES
+
+            // Arrange
+            _fs.AddFile("/logs/app.log", new MockFileData("log1"));
+            _fs.AddFile("/logs/sub/debug.log", new MockFileData("log2"));
+            _fs.AddFile("/logs/sub/deep/trace.log", new MockFileData("log3"));
+            _fs.AddFile("/logs/readme.txt", new MockFileData("text"));
+
+            // Act
+            var results = new List<ClientFile>();
+            await foreach (var file in _sut.GetFilesAsync("/logs/**/*.log"))
+            {
+                results.Add(file);
+            }
+
+            // Assert
+            results.Should().HaveCount(3);
+            results.Select(f => f.FileName).Should().BeEquivalentTo("app.log", "debug.log", "trace.log");
+
+            foreach (var file in results)
+                await file.DisposeAsync();
+        }
+
+        [TestMethod]
+        public async Task GetFilesAsync_NoMatches_ReturnsEmpty()
+        {
+            // Test Validity Check:
+            //   Invokes code under test: YES (GetFilesAsync)
+            //   Breakage detection: YES (verifies empty result, not error)
+            //   Not a tautology: YES
+
+            // Arrange
+            _fs.AddFile("/data/file.txt", new MockFileData("text"));
+
+            // Act
+            var results = new List<ClientFile>();
+            await foreach (var file in _sut.GetFilesAsync("/data/*.csv"))
+            {
+                results.Add(file);
+            }
+
+            // Assert
+            results.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public async Task GetFilesAsync_QuestionMark_MatchesSingleChar()
+        {
+            // Test Validity Check:
+            //   Invokes code under test: YES (GetFilesAsync)
+            //   Breakage detection: YES (verifies ? wildcard filtering)
+            //   Not a tautology: YES
+
+            // Arrange
+            _fs.AddFile("/data/file1.txt", new MockFileData("a"));
+            _fs.AddFile("/data/file2.txt", new MockFileData("b"));
+            _fs.AddFile("/data/file10.txt", new MockFileData("c"));
+
+            // Act
+            var results = new List<ClientFile>();
+            await foreach (var file in _sut.GetFilesAsync("/data/file?.txt"))
+            {
+                results.Add(file);
+            }
+
+            // Assert
+            results.Should().HaveCount(2);
+            results.Select(f => f.FileName).Should().BeEquivalentTo("file1.txt", "file2.txt");
+
+            foreach (var file in results)
+                await file.DisposeAsync();
+        }
+
+        [TestMethod]
+        public async Task GetFilesAsync_LazyEnumeration_OpensFilesOnDemand()
+        {
+            // Test Validity Check:
+            //   Invokes code under test: YES (GetFilesAsync with partial iteration)
+            //   Breakage detection: YES (verifies only 2 of 5 streams opened)
+            //   Not a tautology: YES
+
+            // Arrange
+            for (int i = 1; i <= 5; i++)
+                _fs.AddFile($"/data/file{i}.csv", new MockFileData($"content{i}"));
+
+            // Act — iterate only first 2
+            var opened = new List<ClientFile>();
+            int count = 0;
+            await foreach (var file in _sut.GetFilesAsync("/data/*.csv"))
+            {
+                opened.Add(file);
+                count++;
+                if (count >= 2)
+                    break;
+            }
+
+            // Assert
+            opened.Should().HaveCount(2);
+            opened[0].Stream.CanRead.Should().BeTrue();
+            opened[1].Stream.CanRead.Should().BeTrue();
+
+            foreach (var file in opened)
+                await file.DisposeAsync();
+        }
+
+        [TestMethod]
+        public async Task GetFilesAsync_NonExistentDirectory_ReturnsEmpty()
+        {
+            // Test Validity Check:
+            //   Invokes code under test: YES (GetFilesAsync)
+            //   Breakage detection: YES (verifies no error on missing dir)
+            //   Not a tautology: YES
+
+            // Act
+            var results = new List<ClientFile>();
+            await foreach (var file in _sut.GetFilesAsync("/nonexistent/*.txt"))
+            {
+                results.Add(file);
+            }
+
+            // Assert
+            results.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public async Task GetFilesAsync_EachFileIsIndependentlyDisposable()
+        {
+            // Test Validity Check:
+            //   Invokes code under test: YES (GetFilesAsync + DisposeAsync)
+            //   Breakage detection: YES (verifies independent disposal)
+            //   Not a tautology: YES
+
+            // Arrange
+            _fs.AddFile("/data/a.txt", new MockFileData("aaa"));
+            _fs.AddFile("/data/b.txt", new MockFileData("bbb"));
+
+            // Act
+            var files = new List<ClientFile>();
+            await foreach (var file in _sut.GetFilesAsync("/data/*.txt"))
+                files.Add(file);
+
+            // Dispose first, second should still be readable
+            await files[0].DisposeAsync();
+            files[1].Stream.CanRead.Should().BeTrue();
+            await files[1].DisposeAsync();
         }
     }
 }

--- a/BitPantry.CommandLine/BitPantry.CommandLine.csproj
+++ b/BitPantry.CommandLine/BitPantry.CommandLine.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.Linq.Dynamic.Core" />

--- a/BitPantry.CommandLine/Client/IClientFileAccess.cs
+++ b/BitPantry.CommandLine/Client/IClientFileAccess.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +22,18 @@ namespace BitPantry.CommandLine.Client
         /// <returns>A <see cref="ClientFile"/> providing stream access to the file.</returns>
         /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
         Task<ClientFile> GetFileAsync(string clientPath, IProgress<FileTransferProgress> progress = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Opens multiple files matching a glob pattern on the client machine.
+        /// Files are transferred lazily — each file is opened/transferred only when
+        /// the caller iterates to it. Each yielded <see cref="ClientFile"/> is
+        /// independently disposable.
+        /// </summary>
+        /// <param name="clientGlobPattern">Glob pattern to match files (e.g., "*.csv", "**/*.log").</param>
+        /// <param name="progress">Optional progress callback for transfer reporting.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>An async enumerable of <see cref="ClientFile"/> instances for each match.</returns>
+        IAsyncEnumerable<ClientFile> GetFilesAsync(string clientGlobPattern, IProgress<FileTransferProgress> progress = null, CancellationToken ct = default);
 
         /// <summary>
         /// Saves a stream to a file on the client machine.

--- a/BitPantry.CommandLine/Client/LocalClientFileAccess.cs
+++ b/BitPantry.CommandLine/Client/LocalClientFileAccess.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace BitPantry.CommandLine.Client
 {
@@ -33,6 +38,20 @@ namespace BitPantry.CommandLine.Client
             progress?.Report(new FileTransferProgress(length, length));
 
             return Task.FromResult(new ClientFile(stream, fileName, length));
+        }
+
+        public async IAsyncEnumerable<ClientFile> GetFilesAsync(
+            string clientGlobPattern,
+            IProgress<FileTransferProgress> progress = null,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var matchedFiles = ExpandGlob(clientGlobPattern);
+
+            foreach (var filePath in matchedFiles)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return await GetFileAsync(filePath, progress, ct);
+            }
         }
 
         public async Task SaveFileAsync(Stream content, string clientPath, IProgress<FileTransferProgress> progress = null, CancellationToken ct = default)
@@ -84,6 +103,99 @@ namespace BitPantry.CommandLine.Client
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Expands a glob pattern against the local file system and returns matching full paths.
+        /// Uses Microsoft.Extensions.FileSystemGlobbing for pattern matching and a regex
+        /// post-filter for ? wildcards (which FileSystemGlobbing doesn't support natively).
+        /// </summary>
+        internal List<string> ExpandGlob(string pattern)
+        {
+            var (baseDir, searchPattern) = ParseGlobPattern(pattern);
+
+            if (!_fileSystem.Directory.Exists(baseDir))
+                return new List<string>();
+
+            var originalPattern = searchPattern;
+            var matcherPattern = searchPattern.Replace('?', '*');
+
+            var matcher = new Matcher();
+            matcher.AddInclude(matcherPattern);
+
+            string[] allFiles;
+            try
+            {
+                allFiles = _fileSystem.Directory.GetFiles(baseDir, "*", SearchOption.AllDirectories);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return new List<string>();
+            }
+
+            var inMemoryDir = new InMemoryDirectoryInfo(baseDir, allFiles);
+            var result = matcher.Execute(inMemoryDir);
+
+            var matchedFiles = result.Files
+                .Select(f => _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine(baseDir, f.Path)))
+                .ToList();
+
+            // Apply ? wildcard post-filtering
+            if (originalPattern.Contains('?'))
+            {
+                var regex = GlobPatternToRegex(originalPattern);
+                matchedFiles = matchedFiles
+                    .Where(f => regex.IsMatch(_fileSystem.Path.GetFileName(f)))
+                    .ToList();
+            }
+
+            return matchedFiles;
+        }
+
+        private (string baseDir, string pattern) ParseGlobPattern(string source)
+        {
+            var normalizedSource = source.Replace('\\', '/');
+            var segments = normalizedSource.Split('/');
+
+            var baseSegments = new List<string>();
+            var patternSegments = new List<string>();
+            var inPattern = false;
+
+            foreach (var seg in segments)
+            {
+                if (inPattern || seg.Contains('*') || seg.Contains('?'))
+                {
+                    inPattern = true;
+                    patternSegments.Add(seg);
+                }
+                else
+                {
+                    baseSegments.Add(seg);
+                }
+            }
+
+            var baseDir = baseSegments.Count > 0
+                ? string.Join(_fileSystem.Path.DirectorySeparatorChar.ToString(), baseSegments)
+                : _fileSystem.Directory.GetCurrentDirectory();
+
+            if (string.IsNullOrWhiteSpace(baseDir))
+                baseDir = _fileSystem.Directory.GetCurrentDirectory();
+
+            var resultPattern = string.Join("/", patternSegments);
+
+            return (baseDir, resultPattern);
+        }
+
+        private static Regex GlobPatternToRegex(string pattern)
+        {
+            var segments = pattern.Replace('\\', '/').Split('/');
+            var filePattern = segments[^1];
+
+            var regexPattern = Regex.Escape(filePattern)
+                .Replace("\\*", ".*")
+                .Replace("\\?", ".");
+
+            return new Regex($"^{regexPattern}$", RegexOptions.IgnoreCase);
         }
 
         private void EnsureParentDirectory(string filePath)


### PR DESCRIPTION
Closes #57

## Changes

- Added `GetFilesAsync(string clientGlobPattern, ...)` to `IClientFileAccess` returning `IAsyncEnumerable<ClientFile>` (FR-021)
- Implemented `LocalClientFileAccess.GetFilesAsync` with glob expansion via `Microsoft.Extensions.FileSystemGlobbing` and `?` wildcard post-filter (FR-022, FR-024)
- Implemented `RemoteClientFileAccess.GetFilesAsync` with `ClientFileEnumerateRequest` → lazy per-file `ClientFileUploadRequest` flow (FR-023)
- Client-side glob expansion in `FileAccessConsentHandler.ExpandGlobLocally` with batched consent via `RequestBatchConsentAsync` (tiered display: ≤10 full list, 11-50 collapsed, >50 summary)
- Client-side handling of `ClientFileEnumerateRequest` in `SignalRServerProxy.ReceiveMessage`
- Unit tests for local GetFilesAsync (star glob, double-star recursive, no matches, question mark, lazy enumeration, non-existent directory, independent disposal)
- Unit tests for remote GetFilesAsync (enumerate request, matching files yield, client denial, empty response, lazy transfer)
- Integration tests for GetFilesAsync (glob pattern matching, lazy enumeration, batch consent small set, batch consent large set) — blocked by #67 (RpcMessageRegistry scoping), marked [Ignore]
- `TestGetFilesCommand` test command supporting `--limit` for lazy enumeration testing

## Testing

- All 977 core tests pass
- All 981 remote tests pass (11 skipped — existing + new [Ignore] tests blocked by #67)
- Build succeeds with 0 warnings, 0 errors